### PR TITLE
Adds teardown to tests

### DIFF
--- a/tests/bulk/10_basic.yml
+++ b/tests/bulk/10_basic.yml
@@ -21,3 +21,9 @@
         index: test_serverless_bulk_10
 
   - match: {count: 2}
+
+---
+  teardown:
+    - do:
+        indices.delete:
+          index: test_serverless_bulk_10

--- a/tests/delete/10_basic.yml
+++ b/tests/delete/10_basic.yml
@@ -15,3 +15,9 @@
           id:     "1"
 
  - match: { result: deleted }
+
+---
+  teardown:
+    - do:
+        indices.delete:
+          index: test_serverless_delete_10

--- a/tests/get/10_basic.yml
+++ b/tests/get/10_basic.yml
@@ -15,3 +15,9 @@
   - match: { _index:   "test_serverless_get_10" }
   - match: { _id:      "1"      }
   - match: { _source:  { "foo": "bar"} }
+
+---
+  teardown:
+    - do:
+        indices.delete:
+          index: test_serverless_get_10

--- a/tests/index/10_with_id.yml
+++ b/tests/index/10_with_id.yml
@@ -20,3 +20,9 @@
  - match: { _id:      "1" }
  - match: { _version: 1 }
  - match: { _source: { "foo": "bar" }}
+
+---
+  teardown:
+    - do:
+        indices.delete:
+          index: test_serverless_index_10

--- a/tests/index/20_without_id.yml
+++ b/tests/index/20_without_id.yml
@@ -18,3 +18,9 @@
   - match: { _index:   test_serverless_index_20 }
   - match: { _id:      $id }
   - match: { _source: { "foo": "bar" } }
+
+---
+  teardown:
+    - do:
+        indices.delete:
+          index: test_serverless_index_20

--- a/tests/update/10_partial_update.yml
+++ b/tests/update/10_partial_update.yml
@@ -33,3 +33,9 @@
   - match: { _source.count:      1   }
   - match: { _source.nested.one: 3   }
   - match: { _source.nested.two: 2   }
+
+---
+  teardown:
+    - do:
+        indices.delete:
+          index: test_serverless_update_10


### PR DESCRIPTION
One of the biggest issues with the other test suite is there is no proper teardown. By adding a teardown section to each test, we better avoid conflicts and we don't need to have a `wipe_cluster` function we run for every single test.