### PR TITLE
Use correct shard count for indices refresh test

### DIFF
--- a/tests/indices/refresh.yml
+++ b/tests/indices/refresh.yml
@@ -15,4 +15,4 @@ teardown:
       indices.refresh:
         index: 'indices_refresh_get'
 
-  - match: { _shards.successful: 1 }
+  - match: { _shards.successful: 3 }


### PR DESCRIPTION
This test keeps failing for me. Maybe [3-shard clusters](https://groups.google.com/a/elastic.co/g/es/c/HbF5rLRSCnc) are being tested on QA? If that's the case we might want to adjust this test to make it less brittle, or just skip it until that decision is final and deployed everywhere.