### PR TITLE
Use date string for start date

### DIFF
--- a/tests/machine_learning/start_stop_datafeed.yml
+++ b/tests/machine_learning/start_stop_datafeed.yml
@@ -57,7 +57,7 @@ teardown:
   - do:
       ml.start_datafeed:
         datafeed_id: "start-stop-datafeed-datafeed-1"
-        start: 0
+        start: "1970-01-01T00:00:00.000Z"
   - do:
       ml.get_datafeed_stats:
         datafeed_id: "start-stop-datafeed-datafeed-1"


### PR DESCRIPTION
JS doesn't cast `0` to a date, so this test was failing. Explicitly setting it to the equivalent date string makes it pass.
