### PR TITLE
Updates report coverage

### DIFF
--- a/report/reporter.rb
+++ b/report/reporter.rb
@@ -53,9 +53,12 @@ module Elastic
       end
     end
 
-    def coverage
-      percentage = @tested.count * 100 / @apis[:json].count
-      "![](https://geps.dev/progress/#{percentage})"
+    def coverage_serverless
+      @tested.count * 100 / serverless_apis.count
+    end
+
+    def coverage_stack
+      @tested.count * 100 / @apis[:json].count
     end
 
     private

--- a/report/template.erb
+++ b/report/template.erb
@@ -5,7 +5,8 @@
 * Endpoints in Serverless: <%= @reporter.serverless_apis.count %>
 * [Tested](#tested): <%= @reporter.tested.count %>
 * [Untested](#untested): <%= @reporter.untested.count %>
-* Coverage: <%= @reporter.coverage %>
+* Coverage Stack: ![](https://geps.dev/progress/<%= @reporter.coverage_stack %>)
+* Coverage Serverless: ![](https://geps.dev/progress/<%= @reporter.coverage_serverless %>)
 
 ## Tested
 


### PR DESCRIPTION
Adds Serverless/Stack distinction in coverage percentage.

![image](https://github.com/elastic/elasticsearch-clients-tests/assets/689327/2bfc948c-c83b-48f6-acb3-a1eb7f6aa75b)