### PR TITLE
Adds `requires` property to tell serverless/stack tests apart

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,32 @@ This repository holds common tests for Elasticsearch Clients.
 
 The tests are specified using the Elasticsearch YAML format reported [here](https://github.com/elastic/elasticsearch/blob/main/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/README.asciidoc).
 
-All the tests for serverless are located in the [tests](tests) folder. Each API endpoint has a folder
-containing the tests to be executed. All the files must be executed in order, they are enumerated with
-a digit prefix.
+All the tests are located in the [tests](tests) folder. Each API endpoint has a folder containing the tests to be executed. All the files must be executed in order, they are enumerated with a digit prefix.
+
+## Test Sections
+
+### `requires`
+
+This section should define if a test is available for the stack client, serverless client or both with the following format:
+```yaml
+---
+requires:
+  serverless: true
+  stack: true
+```
+
+This helps us differentiate tests for a particular client and define tests in common for both.
 
 ### `setup` and `teardown`
 
 Pre-requisites to run a test (e.g. creating an index, populating an index with data) are declared in a `setup` section. The list of commands in the `setup` section has to run before the test section.
 
 Cleanup is declared in a `teardown` section. This list of commands will run after the tests. **Please add a `teardown` section to your test to remove any created artifacts and data**. This will keep our test clusters clean and our test suite sane.
+
+## APIs Report
+
+[This report](https://github.com/elastic/elasticsearch-clients-tests/blob/main/apis_report.md) contains information from each specification:
+- [Elasticsearch REST API JSON specification](https://github.com/elastic/elasticsearch/tree/main/rest-api-spec)
+- [Elasticsearch API Specification](https://github.com/elastic/elasticsearch-specification/)
+
+It also contains information on test coverage in this project for Serverless and Stack APIs. The report is automatically generated when code is pushed in a [GitHub Action](https://github.com/elastic/elasticsearch-clients-tests/blob/main/.github/workflows/report.yml). It can also be triggered manually. The source code for the report is in the [./report/](./report) directory.

--- a/tests/async_search/10_basic.yml
+++ b/tests/async_search/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       index:

--- a/tests/bulk/10_basic.yml
+++ b/tests/bulk/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 "Basic bulk operation":
 
   - do:

--- a/tests/cat/aliases.yml
+++ b/tests/cat/aliases.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/cat/component_templates.yml
+++ b/tests/cat/component_templates.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 "cat.component_templates":
 
   - do:

--- a/tests/cat/count.yml
+++ b/tests/cat/count.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       index:

--- a/tests/cat/help.yml
+++ b/tests/cat/help.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 "cat.help":
 
   - do:

--- a/tests/cat/indices.yml
+++ b/tests/cat/indices.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/cat/ml.yml
+++ b/tests/cat/ml.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 "cat.ml":
   - do:
       cat.ml_data_frame_analytics

--- a/tests/cat/transform.yml
+++ b/tests/cat/transform.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       index:

--- a/tests/cluster/cluster_info.yml
+++ b/tests/cluster/cluster_info.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 'cluster.info':
   - do:
       cluster.info:

--- a/tests/cluster/component_templates.yml
+++ b/tests/cluster/component_templates.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 'cluster.component_templates':
   - do:
       cluster.put_component_template:

--- a/tests/count/10_basic.yml
+++ b/tests/count/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/create/10_basic.yml
+++ b/tests/create/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/delete/10_basic.yml
+++ b/tests/delete/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 "Basic":
   - do:
       index:

--- a/tests/delete_by_query/10_basic.yml
+++ b/tests/delete_by_query/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/enrich/10_basic.yml
+++ b/tests/enrich/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/eql/10_basic.yml
+++ b/tests/eql/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/exists/10_basic.yml
+++ b/tests/exists/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 teardown:
   - do:
       indices.delete:

--- a/tests/exists_source/10_basic.yml
+++ b/tests/exists_source/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 teardown:
   - do:
       indices.delete:

--- a/tests/explain/10_basic.yml
+++ b/tests/explain/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/field_caps/10_basic.yml
+++ b/tests/field_caps/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/get.yml
+++ b/tests/get.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create: { index: 'get_test' }

--- a/tests/get/10_basic.yml
+++ b/tests/get/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 "Basic":
 
   - do:

--- a/tests/get_source/10_basic.yml
+++ b/tests/get_source/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 teardown:
   - do:
       indices.delete:

--- a/tests/graph/explore.yml
+++ b/tests/graph/explore.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/index/10_with_id.yml
+++ b/tests/index/10_with_id.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 "Index with ID":
 
   - do:

--- a/tests/index/20_without_id.yml
+++ b/tests/index/20_without_id.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 "Index without ID":
 
   - do:

--- a/tests/indices/alias.yml
+++ b/tests/indices/alias.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/indices/analyze.yml
+++ b/tests/indices/analyze.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/indices/block.yml
+++ b/tests/indices/block.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create: { index: block_test_index }

--- a/tests/indices/create.yml
+++ b/tests/indices/create.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 teardown:
   - do:
       indices.delete:

--- a/tests/indices/data_lifecycle.yml
+++ b/tests/indices/data_lifecycle.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create: { index: 'my-data-stream' }

--- a/tests/indices/data_streams.yml
+++ b/tests/indices/data_streams.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.put_index_template:

--- a/tests/indices/delete.yml
+++ b/tests/indices/delete.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/indices/exists.yml
+++ b/tests/indices/exists.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/indices/get.yml
+++ b/tests/indices/get.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/indices/index_template.yml
+++ b/tests/indices/index_template.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 teardown:
   - do:
       indices.delete_index_template:

--- a/tests/indices/mapping.yml
+++ b/tests/indices/mapping.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/indices/migrate_modify_data_stream.yml
+++ b/tests/indices/migrate_modify_data_stream.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       index:

--- a/tests/indices/refresh.yml
+++ b/tests/indices/refresh.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/indices/resolve.yml
+++ b/tests/indices/resolve.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/indices/rollover.yml
+++ b/tests/indices/rollover.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 teardown:
   - do:
       indices.delete: { index: logs-1 }

--- a/tests/indices/settings.yml
+++ b/tests/indices/settings.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/indices/simulate_index_template.yml
+++ b/tests/indices/simulate_index_template.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 teardown:
   - do:
       indices.delete_index_template:

--- a/tests/indices/simulate_template.yml
+++ b/tests/indices/simulate_template.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 teardown:
   - do:
       indices.delete_index_template:

--- a/tests/info.yml
+++ b/tests/info.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 'info':
   - do:
       info: {}

--- a/tests/ingest/10_basic.yml
+++ b/tests/ingest/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 'ingest':
   - do:
       ingest.put_pipeline:

--- a/tests/license.yml
+++ b/tests/license.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 'license':
   - do:
       license.get: {}

--- a/tests/logstash/10_basic.yml
+++ b/tests/logstash/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 'logstash pipeline':
   - do:
       logstash.put_pipeline:

--- a/tests/machine_learning/calendar_crud.yml
+++ b/tests/machine_learning/calendar_crud.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 teardown:
   - do:
       ml.delete_calendar:

--- a/tests/machine_learning/calendar_events_crud.yml
+++ b/tests/machine_learning/calendar_events_crud.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 teardown:
   - do:
       ml.delete_calendar: { calendar_id: "events" }

--- a/tests/machine_learning/calendar_job.yml
+++ b/tests/machine_learning/calendar_job.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       ml.put_calendar:

--- a/tests/machine_learning/data_frame_analytics.yml
+++ b/tests/machine_learning/data_frame_analytics.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/machine_learning/data_frame_evaluate.yml
+++ b/tests/machine_learning/data_frame_evaluate.yml
@@ -1,3 +1,7 @@
+---
+requires:
+  serverless: true
+  stack: true
 setup:
   - do:
       indices.create:

--- a/tests/machine_learning/datafeed_crud.yml
+++ b/tests/machine_learning/datafeed_crud.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       ml.put_job:

--- a/tests/machine_learning/estimate_model_memory.yml
+++ b/tests/machine_learning/estimate_model_memory.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 "Test by field":
   - do:
       ml.estimate_model_memory:

--- a/tests/machine_learning/filter_crud.yml
+++ b/tests/machine_learning/filter_crud.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       ml.put_filter:

--- a/tests/machine_learning/get_overall_buckets.yml
+++ b/tests/machine_learning/get_overall_buckets.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 "Test overall buckets given non-matching expression and allow_no_match":
   - do:
       ml.get_overall_buckets:

--- a/tests/machine_learning/jobs_crud.yml
+++ b/tests/machine_learning/jobs_crud.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 teardown:
   - do:
       ml.delete_job:

--- a/tests/machine_learning/jobs_reset.yml
+++ b/tests/machine_learning/jobs_reset.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       ml.put_job:

--- a/tests/machine_learning/preview_datafeed.yml
+++ b/tests/machine_learning/preview_datafeed.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 teardown:
   - do:
       indices.delete: { index: airline-data }

--- a/tests/machine_learning/start_stop_datafeed.yml
+++ b/tests/machine_learning/start_stop_datafeed.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/machine_learning/trained_model.yml
+++ b/tests/machine_learning/trained_model.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 "Trained models":
   - do:
       ml.put_trained_model:

--- a/tests/machine_learning/trained_model_aliases.yml
+++ b/tests/machine_learning/trained_model_aliases.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 teardown:
   - do:
       ml.delete_trained_model: { model_id: a-classification-model, force: true }

--- a/tests/machine_learning/trained_model_more.yml
+++ b/tests/machine_learning/trained_model_more.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 teardown:
   - do:
       ml.delete_trained_model: { model_id: "test_model", force: true }

--- a/tests/mget.yml
+++ b/tests/mget.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       bulk:

--- a/tests/msearch.yml
+++ b/tests/msearch.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create: { index: 'msearch_test' }

--- a/tests/msearch_template.yml
+++ b/tests/msearch_template.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create: { index: 'msearch_template_test' }

--- a/tests/mtermvectors/10_basic.yml
+++ b/tests/mtermvectors/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/ping/ping.yml
+++ b/tests/ping/ping.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 'ping':
   - do:
       ping: {}

--- a/tests/point_in_time/10_basic.yml
+++ b/tests/point_in_time/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create: { index: 'pit_test' }

--- a/tests/query_ruleset/10_basic.yml
+++ b/tests/query_ruleset/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 'put ruleset':
   - do:
       query_ruleset.put:

--- a/tests/rank_eval.yml
+++ b/tests/rank_eval.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       index:

--- a/tests/reindex/10_basic.yml
+++ b/tests/reindex/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create: { index: 'reindex_test' }

--- a/tests/script/10_basic.yml
+++ b/tests/script/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create: { index: 'script_test' }

--- a/tests/scroll/10_basic.yml
+++ b/tests/scroll/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/search/10_basic.yml
+++ b/tests/search/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 teardown:
   - do:
       indices.delete: { index: 'search_test' }

--- a/tests/search_application/10_basic.yml
+++ b/tests/search_application/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/search_application/20_behavioral_analytics.yml
+++ b/tests/search_application/20_behavioral_analytics.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 'behavioral_analytics':
   - do:
       search_application.put_behavioral_analytics:

--- a/tests/search_mvt/10_basic.yml
+++ b/tests/search_mvt/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create:

--- a/tests/search_template/10_basic.yml
+++ b/tests/search_template/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create: { index: 'render_search_template' }

--- a/tests/security/10_api_key_basic.yml
+++ b/tests/security/10_api_key_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 'API Key':
   - do:
       security.create_api_key:

--- a/tests/security/20_authenticate.yml
+++ b/tests/security/20_authenticate.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 'security.authenticate':
   - do:
       security.authenticate: {}

--- a/tests/security/30_has_privileges.yml
+++ b/tests/security/30_has_privileges.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 'security.has_privileges':
   - do:
       security.has_privileges:

--- a/tests/sql/10_basic.yml
+++ b/tests/sql/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create: { index: 'sql_test' }

--- a/tests/synonyms/10_basic.yml
+++ b/tests/synonyms/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create: { index: 'synonyms_test' }

--- a/tests/terms_enum/10_basic.yml
+++ b/tests/terms_enum/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create: { index: 'terms_enum_test' }

--- a/tests/termvectors/10_basic.yml
+++ b/tests/termvectors/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create: { index: 'termvectors_test' }

--- a/tests/transform/10_basic.yml
+++ b/tests/transform/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create: { index: 'transforms_test' }

--- a/tests/update/10_partial_update.yml
+++ b/tests/update/10_partial_update.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 "Partial document":
 
   - do:

--- a/tests/update_by_query/10_basic.yml
+++ b/tests/update_by_query/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create: { index: 'update_by_query' }

--- a/tests/validate_query/10_basic.yml
+++ b/tests/validate_query/10_basic.yml
@@ -1,4 +1,8 @@
 ---
+requires:
+  serverless: true
+  stack: true
+---
 setup:
   - do:
       indices.create: { index: 'validate_query_test' }


### PR DESCRIPTION
This is an idea we came up with @ezimuel to tell which tests we need to run when using the YAML test runner in `Serverless` or `Stack`. Other ideas we thought about but discarded were:
- Different directories for sets of tests: `common`, `stack`, `serverless`
- Different branches for serverless/stack (but how do we share `common` tests?)

We believe -for now- having `requires` with a boolean property for `serverless` and `stack` will help, and make versioning easier. So we'll have "release branches" like `8.14`, `8.15` for stack tests and `20231031`, etc. for serverless.

We know the tests we've written so far are all `true` for Serverless and Stack, since we haven't added any tests that are exclusive to either yet.

Thinking of if `requires` is required, I'd say so. We should create tests with explicit information as we've been doing to avoid any added complexity. I could write a GitHub Action for PRs that checks that a new test has the `requires` fields for both client types, so we don't forget. 

Also I'm not entirely sure `requires` is the best name for this property, let me know if you have any suggestions.

Additionally, I'm going to add information to the report to help out when writing new tests.