### PR TITLE
Fix cat tests for Python client

### DIFF
--- a/tests/cat/aliases.yml
+++ b/tests/cat/aliases.yml
@@ -19,5 +19,6 @@ teardown:
 ---
 "cat.aliases":
   - do:
-      cat.aliases: {}
-  - match: { $body.0.alias: 'my_alias' }
+      cat.aliases:
+        format: 'json'
+  - match: { 0.alias: 'my_alias' }

--- a/tests/cat/aliases.yml
+++ b/tests/cat/aliases.yml
@@ -21,4 +21,5 @@ teardown:
   - do:
       cat.aliases:
         format: 'json'
+        expand_wildcards: 'open'
   - match: { 0.alias: 'my_alias' }

--- a/tests/cat/component_templates.yml
+++ b/tests/cat/component_templates.yml
@@ -8,4 +8,4 @@ requires:
   - do:
       cat.component_templates: {}
   - match:
-      $body: 'elastic'
+      $body: '/elastic/'

--- a/tests/cat/count.yml
+++ b/tests/cat/count.yml
@@ -19,4 +19,4 @@ teardown:
   - do:
       cat.count: {}
   - match:
-      $body: "\n"
+      $body: "/\n/"

--- a/tests/cat/help.yml
+++ b/tests/cat/help.yml
@@ -8,4 +8,4 @@ requires:
   - do:
       cat.help: {}
   - match:
-      $body: '=^.^='
+      $body: "/=\\^.\\^=/"

--- a/tests/cat/indices.yml
+++ b/tests/cat/indices.yml
@@ -18,4 +18,5 @@ teardown:
   - do:
       cat.indices:
         index: 'test_sl_cat_indices'
-  - match: { $body: 'test_sl_cat_indices' }
+        format: 'json'
+  - match: { 0.index: 'test_sl_cat_indices' }

--- a/tests/cat/ml.yml
+++ b/tests/cat/ml.yml
@@ -5,14 +5,18 @@ requires:
 ---
 "cat.ml":
   - do:
-      cat.ml_data_frame_analytics
+      cat.ml_data_frame_analytics:
+        format: 'json'
   - is_true: ""
   - do:
-      cat.ml_datafeeds
+      cat.ml_datafeeds:
+        format: 'json'
   - is_true: ""
   - do:
-      cat.ml_jobs
+      cat.ml_jobs:
+        format: 'json'
   - is_true: ""
   - do:
-      cat.ml_trained_models
+      cat.ml_trained_models:
+        format: 'json'
   - is_true: ""

--- a/tests/cat/transform.yml
+++ b/tests/cat/transform.yml
@@ -30,5 +30,6 @@ teardown:
 ---
 "cat.transforms":
   - do:
-      cat.transforms: {}
-  - match: { $body: 'transform_id' }
+      cat.transforms:
+        format: 'json'
+  - match: { 0.id: 'transform_id' }


### PR DESCRIPTION
The `cat` tests are failing in Python for two reasons.

1. Python defaults to a text output, which isn't very useful. Switching to the JSON format outputs non-empty responses (useful in the case of ML CAT APIs) and allows checking inside the response with `match`.
2.  According to the [Elasticsearch YAML documentation](https://github.com/elastic/elasticsearch/blob/main/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/README.asciidoc#match), `match` should check if the two variables are identical, which is what Python does. But regexes are also allowed. So I've changed cat.count and cat.help to check the output with a regex.

The tests are now passing in Python, but I don't know if this works in Ruby and JS.