### PR TITLE
Updates reporter - better API detection

### DIFF
--- a/report/reporter.rb
+++ b/report/reporter.rb
@@ -83,7 +83,7 @@ module Elastic
         relative_path = path[path.index('/tests')..-1]
 
         File.readlines(path).each_with_index do |line, index|
-          next unless line.include?(endpoint)
+          next unless line.split(':')[0].strip.gsub('"', '') == endpoint
 
           return { endpoint: endpoint, file: ".#{relative_path}", line: index + 1 }
         end


### PR DESCRIPTION
In [#61](https://github.com/elastic/elasticsearch-clients-tests/pull/61/files#diff-5efae6cf9da586b58153fdd5f03035756a10cd4e54b0a38e80ad3af12c51828eL466-R466) a bug with the endpoint popped up, confusing `sql` with `esql`. This PR improves the string manipulation to compare endpoints with the respective tests.