### PR TITLE
Updates indices.simulate_template and info tests

### DIFF
--- a/tests/indices/simulate_template_serverless.yml
+++ b/tests/indices/simulate_template_serverless.yml
@@ -1,7 +1,7 @@
 ---
 requires:
   serverless: true
-  stack: true
+  stack: false
 ---
 teardown:
   - do:

--- a/tests/indices/simulate_template_stack.yml
+++ b/tests/indices/simulate_template_stack.yml
@@ -1,0 +1,45 @@
+---
+requires:
+  serverless: false
+  stack: true
+---
+teardown:
+  - do:
+      indices.delete_index_template:
+        name: existing_test
+  - do:
+      cluster.delete_component_template:
+        name: ct
+---
+"Simulate template":
+  - do:
+      indices.put_index_template:
+        name: existing_test
+        body:
+          index_patterns: te*
+          priority: 10
+          template:
+            mappings:
+              properties:
+                field:
+                  type: keyword
+
+  - do:
+      cluster.put_component_template:
+        name: ct
+        body:
+          template:
+            mappings:
+              properties:
+                ct_field:
+                  type: keyword
+  - do:
+      indices.simulate_index_template:
+        name: test
+        body:
+          index_patterns: t*
+          template:
+            aliases:
+              test_alias: {}
+  - match: { overlapping.0.name: '/simulate_index_template_.*/' }
+  - match: { overlapping.0.index_patterns: ["t*"] }

--- a/tests/info_serverless.yml
+++ b/tests/info_serverless.yml
@@ -1,7 +1,7 @@
 ---
 requires:
   serverless: true
-  stack: true
+  stack: false
 ---
 'info':
   - do:

--- a/tests/info_stack.yml
+++ b/tests/info_stack.yml
@@ -1,0 +1,9 @@
+---
+requires:
+  serverless: false
+  stack: true
+---
+'info':
+  - do:
+      info: {}
+  - match: { tagline: 'You Know, for Search' }


### PR DESCRIPTION
I finally migrated my test runner to its own library and I'm using it for both Stack and Serverless clients. I found a couple of things that should be different in these tests:

## `info`

Updated to test for Serverless and Stack in different tests.

## `simulate_index_template`

When using simulate_index_template in Serverless with `index_patterns`, it returns the following error:
```
[400] {"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"request [/_index_template/_simulate_index/test] contains unrecognized parameter: [body[index_patterns]]"}],"type":"illegal_argument_exception","reason":"request [/_index_template/_simulate_index/test] contains unrecognized parameter: [body[index_patterns]]"},"status":400}
```

However, it is a required parameter in Stack, so I made 2 different test files for Stack and Serverless.