### PR TITLE
Adds tests for Enterprise Search

### DIFF
--- a/apis_report.md
+++ b/apis_report.md
@@ -2,11 +2,11 @@
 
 Endpoints that are currently being tested are marked as done and link to the test where they're being used.
 
-* [Endpoints in Stack (elasticsearch-specification)](#stack): 499
+* [Endpoints in Stack (elasticsearch-specification)](#stack): 502
 * [Endpoints in Serverless](#serverless): 237
-* [Endpoints in Stack JSON spec](#endpoints-in-stack-json-spec): 492
-* Elasticsearch Stack - **Tested**: 239 | **Untested**: 260 ![](https://geps.dev/progress/48)
-* Elasticsearch Serverless - **Tested** 209 | **Untested**: 28 ![](https://geps.dev/progress/88)
+* [Endpoints in Stack JSON spec](#endpoints-in-stack-json-spec): 502
+* Elasticsearch Stack - **Tested**: 283 | **Untested**: 219 ![](https://geps.dev/progress/56)
+* Elasticsearch Serverless - **Tested** 234 | **Untested**: 3 ![](https://geps.dev/progress/98)
 * [APIs in JSON spec and not in elasticsearch-specification](#apis-in-json-spec-and-not-elasticsearch-specification)
 
 ## Endpoints in elasticsearch-specification
@@ -35,31 +35,31 @@ Endpoints that are currently being tested are marked as done and link to the tes
   - [x] <span title='tested'> [cluster.get_component_template](./tests/cluster/component_templates.yml#L24)</span>
   - [x] <span title='tested'> [cluster.info](./tests/cluster/cluster_info.yml#L8)</span>
   - [x] <span title='tested'> [cluster.put_component_template](./tests/cluster/component_templates.yml#L8)</span>
-  - [ ] <span title='not tested'> connector.check_in</span>
-  - [ ] <span title='not tested'> connector.delete</span>
-  - [ ] <span title='not tested'> connector.get</span>
-  - [ ] <span title='not tested'> connector.last_sync</span>
-  - [ ] <span title='not tested'> connector.list</span>
-  - [ ] <span title='not tested'> connector.post</span>
-  - [ ] <span title='not tested'> connector.put</span>
-  - [ ] <span title='not tested'> connector.sync_job_cancel</span>
-  - [ ] <span title='not tested'> connector.sync_job_delete</span>
-  - [ ] <span title='not tested'> connector.sync_job_get</span>
-  - [ ] <span title='not tested'> connector.sync_job_list</span>
-  - [ ] <span title='not tested'> connector.sync_job_post</span>
-  - [ ] <span title='not tested'> connector.update_active_filtering</span>
-  - [ ] <span title='not tested'> connector.update_api_key_id</span>
-  - [ ] <span title='not tested'> connector.update_configuration</span>
-  - [ ] <span title='not tested'> connector.update_error</span>
-  - [ ] <span title='not tested'> connector.update_filtering</span>
-  - [ ] <span title='not tested'> connector.update_filtering_validation</span>
-  - [ ] <span title='not tested'> connector.update_index_name</span>
-  - [ ] <span title='not tested'> connector.update_name</span>
-  - [ ] <span title='not tested'> connector.update_native</span>
-  - [ ] <span title='not tested'> connector.update_pipeline</span>
-  - [ ] <span title='not tested'> connector.update_scheduling</span>
-  - [ ] <span title='not tested'> connector.update_service_type</span>
-  - [ ] <span title='not tested'> connector.update_status</span>
+  - [x] <span title='tested'> [connector.check_in](./tests/entsearch/20_connector.yml#L21)</span>
+  - [x] <span title='tested'> [connector.delete](./tests/entsearch/20_connector.yml#L55)</span>
+  - [x] <span title='tested'> [connector.get](./tests/entsearch/20_connector.yml#L34)</span>
+  - [x] <span title='tested'> [connector.last_sync](./tests/entsearch/20_connector.yml#L26)</span>
+  - [x] <span title='tested'> [connector.list](./tests/entsearch/20_connector.yml#L41)</span>
+  - [x] <span title='tested'> [connector.post](./tests/entsearch/20_connector.yml#L45)</span>
+  - [x] <span title='tested'> [connector.put](./tests/entsearch/20_connector.yml#L14)</span>
+  - [x] <span title='tested'> [connector.sync_job_cancel](./tests/entsearch/30_sync_jobs_serverless.yml#L39)</span>
+  - [x] <span title='tested'> [connector.sync_job_delete](./tests/entsearch/30_sync_jobs_serverless.yml#L48)</span>
+  - [x] <span title='tested'> [connector.sync_job_get](./tests/entsearch/30_sync_jobs_serverless.yml#L33)</span>
+  - [x] <span title='tested'> [connector.sync_job_list](./tests/entsearch/30_sync_jobs_serverless.yml#L44)</span>
+  - [x] <span title='tested'> [connector.sync_job_post](./tests/entsearch/30_sync_jobs_serverless.yml#L24)</span>
+  - [x] <span title='tested'> [connector.update_active_filtering](./tests/entsearch/50_connector_updates.yml#L63)</span>
+  - [x] <span title='tested'> [connector.update_api_key_id](./tests/entsearch/50_connector_updates.yml#L240)</span>
+  - [x] <span title='tested'> [connector.update_configuration](./tests/entsearch/50_connector_updates.yml#L85)</span>
+  - [x] <span title='tested'> [connector.update_error](./tests/entsearch/50_connector_updates.yml#L78)</span>
+  - [x] <span title='tested'> [connector.update_filtering](./tests/entsearch/50_connector_updates.yml#L31)</span>
+  - [x] <span title='tested'> [connector.update_filtering_validation](./tests/entsearch/50_connector_updates.yml#L53)</span>
+  - [x] <span title='tested'> [connector.update_index_name](./tests/entsearch/50_connector_updates.yml#L136)</span>
+  - [x] <span title='tested'> [connector.update_name](./tests/entsearch/50_connector_updates.yml#L24)</span>
+  - [x] <span title='tested'> [connector.update_native](./tests/entsearch/50_connector_updates.yml#L158)</span>
+  - [x] <span title='tested'> [connector.update_pipeline](./tests/entsearch/50_connector_updates.yml#L171)</span>
+  - [x] <span title='tested'> [connector.update_scheduling](./tests/entsearch/50_connector_updates.yml#L190)</span>
+  - [x] <span title='tested'> [connector.update_service_type](./tests/entsearch/50_connector_updates.yml#L228)</span>
+  - [x] <span title='tested'> [connector.update_status](./tests/entsearch/50_connector_updates.yml#L216)</span>
   - [x] <span title='tested'> [count](./tests/bulk/10_basic.yml#L24)</span>
   - [x] <span title='tested'> [create](./tests/create/10_basic.yml#L18)</span>
   - [x] <span title='tested'> [delete](./tests/delete/10_basic.yml#L16)</span>
@@ -316,36 +316,36 @@ Endpoints that are currently being tested are marked as done and link to the tes
   - [x] <span title='tested'> [cluster.reroute](./tests/cluster/reroute.yml#L8)</span>
   - [x] <span title='tested'> [cluster.state](./tests/cluster/state.yml#L8)</span>
   - [x] <span title='tested'> [cluster.stats](./tests/cluster/stats.yml#L8)</span>
-  - [ ] <span title='not tested'> connector.check_in</span>
-  - [ ] <span title='not tested'> connector.delete</span>
-  - [ ] <span title='not tested'> connector.get</span>
-  - [ ] <span title='not tested'> connector.last_sync</span>
-  - [ ] <span title='not tested'> connector.list</span>
-  - [ ] <span title='not tested'> connector.post</span>
-  - [ ] <span title='not tested'> connector.put</span>
-  - [ ] <span title='not tested'> connector.sync_job_cancel</span>
-  - [ ] <span title='not tested'> connector.sync_job_check_in</span>
-  - [ ] <span title='not tested'> connector.sync_job_claim</span>
-  - [ ] <span title='not tested'> connector.sync_job_delete</span>
+  - [x] <span title='tested'> [connector.check_in](./tests/entsearch/20_connector.yml#L21)</span>
+  - [x] <span title='tested'> [connector.delete](./tests/entsearch/20_connector.yml#L55)</span>
+  - [x] <span title='tested'> [connector.get](./tests/entsearch/20_connector.yml#L34)</span>
+  - [x] <span title='tested'> [connector.last_sync](./tests/entsearch/20_connector.yml#L26)</span>
+  - [x] <span title='tested'> [connector.list](./tests/entsearch/20_connector.yml#L41)</span>
+  - [x] <span title='tested'> [connector.post](./tests/entsearch/20_connector.yml#L45)</span>
+  - [x] <span title='tested'> [connector.put](./tests/entsearch/20_connector.yml#L14)</span>
+  - [x] <span title='tested'> [connector.sync_job_cancel](./tests/entsearch/30_sync_jobs_serverless.yml#L39)</span>
+  - [x] <span title='tested'> [connector.sync_job_check_in](./tests/entsearch/30_sync_jobs_stack.yml#L34)</span>
+  - [x] <span title='tested'> [connector.sync_job_claim](./tests/entsearch/30_sync_jobs_stack.yml#L65)</span>
+  - [x] <span title='tested'> [connector.sync_job_delete](./tests/entsearch/30_sync_jobs_serverless.yml#L48)</span>
   - [ ] <span title='not tested'> connector.sync_job_error</span>
-  - [ ] <span title='not tested'> connector.sync_job_get</span>
-  - [ ] <span title='not tested'> connector.sync_job_list</span>
-  - [ ] <span title='not tested'> connector.sync_job_post</span>
-  - [ ] <span title='not tested'> connector.sync_job_update_stats</span>
-  - [ ] <span title='not tested'> connector.update_active_filtering</span>
-  - [ ] <span title='not tested'> connector.update_api_key_id</span>
-  - [ ] <span title='not tested'> connector.update_configuration</span>
-  - [ ] <span title='not tested'> connector.update_error</span>
-  - [ ] <span title='not tested'> connector.update_features</span>
-  - [ ] <span title='not tested'> connector.update_filtering</span>
-  - [ ] <span title='not tested'> connector.update_filtering_validation</span>
-  - [ ] <span title='not tested'> connector.update_index_name</span>
-  - [ ] <span title='not tested'> connector.update_name</span>
-  - [ ] <span title='not tested'> connector.update_native</span>
-  - [ ] <span title='not tested'> connector.update_pipeline</span>
-  - [ ] <span title='not tested'> connector.update_scheduling</span>
-  - [ ] <span title='not tested'> connector.update_service_type</span>
-  - [ ] <span title='not tested'> connector.update_status</span>
+  - [x] <span title='tested'> [connector.sync_job_get](./tests/entsearch/30_sync_jobs_serverless.yml#L33)</span>
+  - [x] <span title='tested'> [connector.sync_job_list](./tests/entsearch/30_sync_jobs_serverless.yml#L44)</span>
+  - [x] <span title='tested'> [connector.sync_job_post](./tests/entsearch/30_sync_jobs_serverless.yml#L24)</span>
+  - [x] <span title='tested'> [connector.sync_job_update_stats](./tests/entsearch/30_sync_jobs_stack.yml#L44)</span>
+  - [x] <span title='tested'> [connector.update_active_filtering](./tests/entsearch/50_connector_updates.yml#L63)</span>
+  - [x] <span title='tested'> [connector.update_api_key_id](./tests/entsearch/50_connector_updates.yml#L240)</span>
+  - [x] <span title='tested'> [connector.update_configuration](./tests/entsearch/50_connector_updates.yml#L85)</span>
+  - [x] <span title='tested'> [connector.update_error](./tests/entsearch/50_connector_updates.yml#L78)</span>
+  - [x] <span title='tested'> [connector.update_features](./tests/entsearch/60_connector_updates_stack.yml#L24)</span>
+  - [x] <span title='tested'> [connector.update_filtering](./tests/entsearch/50_connector_updates.yml#L31)</span>
+  - [x] <span title='tested'> [connector.update_filtering_validation](./tests/entsearch/50_connector_updates.yml#L53)</span>
+  - [x] <span title='tested'> [connector.update_index_name](./tests/entsearch/50_connector_updates.yml#L136)</span>
+  - [x] <span title='tested'> [connector.update_name](./tests/entsearch/50_connector_updates.yml#L24)</span>
+  - [x] <span title='tested'> [connector.update_native](./tests/entsearch/50_connector_updates.yml#L158)</span>
+  - [x] <span title='tested'> [connector.update_pipeline](./tests/entsearch/50_connector_updates.yml#L171)</span>
+  - [x] <span title='tested'> [connector.update_scheduling](./tests/entsearch/50_connector_updates.yml#L190)</span>
+  - [x] <span title='tested'> [connector.update_service_type](./tests/entsearch/50_connector_updates.yml#L228)</span>
+  - [x] <span title='tested'> [connector.update_status](./tests/entsearch/50_connector_updates.yml#L216)</span>
   - [x] <span title='tested'> [count](./tests/bulk/10_basic.yml#L24)</span>
   - [x] <span title='tested'> [create](./tests/create/10_basic.yml#L18)</span>
   - [ ] <span title='not tested'> dangling_indices.delete_dangling_index</span>
@@ -558,7 +558,7 @@ Endpoints that are currently being tested are marked as done and link to the tes
   - [ ] <span title='not tested'> nodes.clear_repositories_metering_archive</span>
   - [ ] <span title='not tested'> nodes.get_repositories_metering_info</span>
   - [ ] <span title='not tested'> nodes.hot_threads</span>
-  - [ ] <span title='not tested'> nodes.info</span>
+  - [x] <span title='tested'> [nodes.info](./tests/entsearch/10_basic.yml#L12)</span>
   - [ ] <span title='not tested'> nodes.reload_secure_settings</span>
   - [ ] <span title='not tested'> nodes.stats</span>
   - [ ] <span title='not tested'> nodes.usage</span>
@@ -592,10 +592,10 @@ Endpoints that are currently being tested are marked as done and link to the tes
   - [x] <span title='tested'> [search_application.get](./tests/search_application/10_basic.yml#L48)</span>
   - [x] <span title='tested'> [search_application.get_behavioral_analytics](./tests/search_application/20_behavioral_analytics.yml#L13)</span>
   - [x] <span title='tested'> [search_application.list](./tests/search_application/10_basic.yml#L58)</span>
-  - [ ] <span title='not tested'> search_application.post_behavioral_analytics_event</span>
+  - [x] <span title='tested'> [search_application.post_behavioral_analytics_event](./tests/search_application/30_behavioral_analytics_event.yml#L18)</span>
   - [x] <span title='tested'> [search_application.put](./tests/search_application/10_basic.yml#L24)</span>
   - [x] <span title='tested'> [search_application.put_behavioral_analytics](./tests/search_application/20_behavioral_analytics.yml#L8)</span>
-  - [ ] <span title='not tested'> search_application.render_query</span>
+  - [x] <span title='tested'> [search_application.render_query](./tests/search_application/40_render_query.yml#L77)</span>
   - [x] <span title='tested'> [search_application.search](./tests/search_application/10_basic.yml#L52)</span>
   - [x] <span title='tested'> [search_mvt](./tests/search_mvt/10_basic.yml#L33)</span>
   - [ ] <span title='not tested'> search_shards</span>
@@ -606,6 +606,8 @@ Endpoints that are currently being tested are marked as done and link to the tes
   - [ ] <span title='not tested'> searchable_snapshots.stats</span>
   - [ ] <span title='not tested'> security.activate_user_profile</span>
   - [x] <span title='tested'> [security.authenticate](./tests/security/20_authenticate.yml#L8)</span>
+  - [x] <span title='tested'> [security.bulk_delete_role](./tests/security/40_roles.yml#L91)</span>
+  - [x] <span title='tested'> [security.bulk_put_role](./tests/security/40_roles.yml#L64)</span>
   - [ ] <span title='not tested'> security.bulk_update_api_keys</span>
   - [ ] <span title='not tested'> security.change_password</span>
   - [ ] <span title='not tested'> security.clear_api_key_cache</span>
@@ -617,10 +619,10 @@ Endpoints that are currently being tested are marked as done and link to the tes
   - [ ] <span title='not tested'> security.create_cross_cluster_api_key</span>
   - [ ] <span title='not tested'> security.create_service_token</span>
   - [ ] <span title='not tested'> security.delete_privileges</span>
-  - [ ] <span title='not tested'> security.delete_role</span>
+  - [x] <span title='tested'> [security.delete_role](./tests/security/40_roles.yml#L23)</span>
   - [ ] <span title='not tested'> security.delete_role_mapping</span>
   - [ ] <span title='not tested'> security.delete_service_token</span>
-  - [ ] <span title='not tested'> security.delete_user</span>
+  - [x] <span title='tested'> [security.delete_user](./tests/security/40_roles.yml#L19)</span>
   - [ ] <span title='not tested'> security.disable_user</span>
   - [ ] <span title='not tested'> security.disable_user_profile</span>
   - [ ] <span title='not tested'> security.enable_user</span>
@@ -630,7 +632,7 @@ Endpoints that are currently being tested are marked as done and link to the tes
   - [x] <span title='tested'> [security.get_api_key](./tests/security/10_api_key_basic.yml#L19)</span>
   - [ ] <span title='not tested'> security.get_builtin_privileges</span>
   - [ ] <span title='not tested'> security.get_privileges</span>
-  - [ ] <span title='not tested'> security.get_role</span>
+  - [x] <span title='tested'> [security.get_role](./tests/security/40_roles.yml#L47)</span>
   - [ ] <span title='not tested'> security.get_role_mapping</span>
   - [ ] <span title='not tested'> security.get_service_accounts</span>
   - [ ] <span title='not tested'> security.get_service_credentials</span>
@@ -648,10 +650,11 @@ Endpoints that are currently being tested are marked as done and link to the tes
   - [ ] <span title='not tested'> security.oidc_logout</span>
   - [ ] <span title='not tested'> security.oidc_prepare_authentication</span>
   - [ ] <span title='not tested'> security.put_privileges</span>
-  - [ ] <span title='not tested'> security.put_role</span>
+  - [x] <span title='tested'> [security.put_role](./tests/security/40_roles.yml#L29)</span>
   - [ ] <span title='not tested'> security.put_role_mapping</span>
-  - [ ] <span title='not tested'> security.put_user</span>
+  - [x] <span title='tested'> [security.put_user](./tests/security/40_roles.yml#L8)</span>
   - [x] <span title='tested'> [security.query_api_keys](./tests/security/10_api_key_basic.yml#L24)</span>
+  - [x] <span title='tested'> [security.query_role](./tests/security/40_roles.yml#L55)</span>
   - [ ] <span title='not tested'> security.query_user</span>
   - [ ] <span title='not tested'> security.saml_authenticate</span>
   - [ ] <span title='not tested'> security.saml_complete_logout</span>
@@ -738,7 +741,7 @@ Endpoints that are currently being tested are marked as done and link to the tes
   - [ ] <span title='not tested'> watcher.stop</span>
   - [ ] <span title='not tested'> watcher.update_settings</span>
   - [ ] <span title='not tested'> xpack.info</span>
-  - [ ] <span title='not tested'> xpack.usage</span>
+  - [x] <span title='tested'> [xpack.usage](./tests/entsearch/10_basic.yml#L16)</span>
 
 
 ## Endpoints in stack JSON spec
@@ -747,6 +750,7 @@ Endpoints that are currently being tested are marked as done and link to the tes
   - [x] <span title='tested'> [async_search.status](./tests/async_search/10_basic.yml#L48)</span>
   - [x] <span title='tested'> [async_search.submit](./tests/async_search/10_basic.yml#L35)</span>
   - [x] <span title='tested'> [bulk](./tests/bulk/10_basic.yml#L9)</span>
+  - [ ] <span title='not tested'> capabilities</span>
   - [x] <span title='tested'> [cat.aliases](./tests/cat/aliases.yml#L20)</span>
   - [x] <span title='tested'> [cat.allocation](./tests/cat/allocation.yml#L6)</span>
   - [x] <span title='tested'> [cat.component_templates](./tests/cat/component_templates.yml#L6)</span>
@@ -804,38 +808,40 @@ Endpoints that are currently being tested are marked as done and link to the tes
   - [x] <span title='tested'> [cluster.reroute](./tests/cluster/reroute.yml#L8)</span>
   - [x] <span title='tested'> [cluster.state](./tests/cluster/state.yml#L8)</span>
   - [x] <span title='tested'> [cluster.stats](./tests/cluster/stats.yml#L8)</span>
-  - [ ] <span title='not tested'> connector.check_in</span>
-  - [ ] <span title='not tested'> connector.delete</span>
-  - [ ] <span title='not tested'> connector.get</span>
-  - [ ] <span title='not tested'> connector.last_sync</span>
-  - [ ] <span title='not tested'> connector.list</span>
-  - [ ] <span title='not tested'> connector.post</span>
-  - [ ] <span title='not tested'> connector.put</span>
+  - [x] <span title='tested'> [connector.check_in](./tests/entsearch/20_connector.yml#L21)</span>
+  - [x] <span title='tested'> [connector.delete](./tests/entsearch/20_connector.yml#L55)</span>
+  - [x] <span title='tested'> [connector.get](./tests/entsearch/20_connector.yml#L34)</span>
+  - [x] <span title='tested'> [connector.last_sync](./tests/entsearch/20_connector.yml#L26)</span>
+  - [x] <span title='tested'> [connector.list](./tests/entsearch/20_connector.yml#L41)</span>
+  - [x] <span title='tested'> [connector.post](./tests/entsearch/20_connector.yml#L45)</span>
+  - [x] <span title='tested'> [connector.put](./tests/entsearch/20_connector.yml#L14)</span>
   - [ ] <span title='not tested'> connector.secret_delete</span>
-  - [ ] <span title='not tested'> connector.secret_get</span>
-  - [ ] <span title='not tested'> connector.secret_post</span>
-  - [ ] <span title='not tested'> connector.secret_put</span>
-  - [ ] <span title='not tested'> connector.sync_job_cancel</span>
-  - [ ] <span title='not tested'> connector.sync_job_check_in</span>
-  - [ ] <span title='not tested'> connector.sync_job_delete</span>
+  - [x] <span title='tested'> [connector.secret_get](./tests/entsearch/40_connector_secret.yml#L14)</span>
+  - [x] <span title='tested'> [connector.secret_post](./tests/entsearch/40_connector_secret.yml#L8)</span>
+  - [x] <span title='tested'> [connector.secret_put](./tests/entsearch/40_connector_secret.yml#L18)</span>
+  - [x] <span title='tested'> [connector.sync_job_cancel](./tests/entsearch/30_sync_jobs_serverless.yml#L39)</span>
+  - [x] <span title='tested'> [connector.sync_job_check_in](./tests/entsearch/30_sync_jobs_stack.yml#L34)</span>
+  - [x] <span title='tested'> [connector.sync_job_claim](./tests/entsearch/30_sync_jobs_stack.yml#L65)</span>
+  - [x] <span title='tested'> [connector.sync_job_delete](./tests/entsearch/30_sync_jobs_serverless.yml#L48)</span>
   - [ ] <span title='not tested'> connector.sync_job_error</span>
-  - [ ] <span title='not tested'> connector.sync_job_get</span>
-  - [ ] <span title='not tested'> connector.sync_job_list</span>
-  - [ ] <span title='not tested'> connector.sync_job_post</span>
-  - [ ] <span title='not tested'> connector.sync_job_update_stats</span>
-  - [ ] <span title='not tested'> connector.update_active_filtering</span>
-  - [ ] <span title='not tested'> connector.update_api_key_id</span>
-  - [ ] <span title='not tested'> connector.update_configuration</span>
-  - [ ] <span title='not tested'> connector.update_error</span>
-  - [ ] <span title='not tested'> connector.update_filtering</span>
-  - [ ] <span title='not tested'> connector.update_filtering_validation</span>
-  - [ ] <span title='not tested'> connector.update_index_name</span>
-  - [ ] <span title='not tested'> connector.update_name</span>
-  - [ ] <span title='not tested'> connector.update_native</span>
-  - [ ] <span title='not tested'> connector.update_pipeline</span>
-  - [ ] <span title='not tested'> connector.update_scheduling</span>
-  - [ ] <span title='not tested'> connector.update_service_type</span>
-  - [ ] <span title='not tested'> connector.update_status</span>
+  - [x] <span title='tested'> [connector.sync_job_get](./tests/entsearch/30_sync_jobs_serverless.yml#L33)</span>
+  - [x] <span title='tested'> [connector.sync_job_list](./tests/entsearch/30_sync_jobs_serverless.yml#L44)</span>
+  - [x] <span title='tested'> [connector.sync_job_post](./tests/entsearch/30_sync_jobs_serverless.yml#L24)</span>
+  - [x] <span title='tested'> [connector.sync_job_update_stats](./tests/entsearch/30_sync_jobs_stack.yml#L44)</span>
+  - [x] <span title='tested'> [connector.update_active_filtering](./tests/entsearch/50_connector_updates.yml#L63)</span>
+  - [x] <span title='tested'> [connector.update_api_key_id](./tests/entsearch/50_connector_updates.yml#L240)</span>
+  - [x] <span title='tested'> [connector.update_configuration](./tests/entsearch/50_connector_updates.yml#L85)</span>
+  - [x] <span title='tested'> [connector.update_error](./tests/entsearch/50_connector_updates.yml#L78)</span>
+  - [x] <span title='tested'> [connector.update_features](./tests/entsearch/60_connector_updates_stack.yml#L24)</span>
+  - [x] <span title='tested'> [connector.update_filtering](./tests/entsearch/50_connector_updates.yml#L31)</span>
+  - [x] <span title='tested'> [connector.update_filtering_validation](./tests/entsearch/50_connector_updates.yml#L53)</span>
+  - [x] <span title='tested'> [connector.update_index_name](./tests/entsearch/50_connector_updates.yml#L136)</span>
+  - [x] <span title='tested'> [connector.update_name](./tests/entsearch/50_connector_updates.yml#L24)</span>
+  - [x] <span title='tested'> [connector.update_native](./tests/entsearch/50_connector_updates.yml#L158)</span>
+  - [x] <span title='tested'> [connector.update_pipeline](./tests/entsearch/50_connector_updates.yml#L171)</span>
+  - [x] <span title='tested'> [connector.update_scheduling](./tests/entsearch/50_connector_updates.yml#L190)</span>
+  - [x] <span title='tested'> [connector.update_service_type](./tests/entsearch/50_connector_updates.yml#L228)</span>
+  - [x] <span title='tested'> [connector.update_status](./tests/entsearch/50_connector_updates.yml#L216)</span>
   - [x] <span title='tested'> [count](./tests/bulk/10_basic.yml#L24)</span>
   - [x] <span title='tested'> [create](./tests/create/10_basic.yml#L18)</span>
   - [ ] <span title='not tested'> dangling_indices.delete_dangling_index</span>
@@ -947,10 +953,10 @@ Endpoints that are currently being tested are marked as done and link to the tes
   - [ ] <span title='not tested'> indices.unfreeze</span>
   - [x] <span title='tested'> [indices.update_aliases](./tests/indices/alias.yml#L41)</span>
   - [x] <span title='tested'> [indices.validate_query](./tests/validate_query/10_basic.yml#L16)</span>
-  - [ ] <span title='not tested'> inference.delete_model</span>
-  - [ ] <span title='not tested'> inference.get_model</span>
+  - [x] <span title='tested'> [inference.delete](./tests/inference/10_basic.yml#L37)</span>
+  - [x] <span title='tested'> [inference.get](./tests/inference/10_basic.yml#L25)</span>
   - [x] <span title='tested'> [inference.inference](./tests/inference/10_basic.yml#L30)</span>
-  - [ ] <span title='not tested'> inference.put_model</span>
+  - [x] <span title='tested'> [inference.put](./tests/inference/10_basic.yml#L8)</span>
   - [x] <span title='tested'> [info](./tests/info_serverless.yml#L8)</span>
   - [x] <span title='tested'> [ingest.delete_pipeline](./tests/ingest/10_basic.yml#L29)</span>
   - [ ] <span title='not tested'> ingest.geo_ip_stats</span>
@@ -1053,7 +1059,7 @@ Endpoints that are currently being tested are marked as done and link to the tes
   - [ ] <span title='not tested'> nodes.clear_repositories_metering_archive</span>
   - [ ] <span title='not tested'> nodes.get_repositories_metering_info</span>
   - [ ] <span title='not tested'> nodes.hot_threads</span>
-  - [ ] <span title='not tested'> nodes.info</span>
+  - [x] <span title='tested'> [nodes.info](./tests/entsearch/10_basic.yml#L12)</span>
   - [ ] <span title='not tested'> nodes.reload_secure_settings</span>
   - [ ] <span title='not tested'> nodes.stats</span>
   - [ ] <span title='not tested'> nodes.usage</span>
@@ -1064,10 +1070,13 @@ Endpoints that are currently being tested are marked as done and link to the tes
   - [ ] <span title='not tested'> profiling.status</span>
   - [ ] <span title='not tested'> profiling.topn_functions</span>
   - [x] <span title='tested'> [put_script](./tests/msearch_template.yml#L10)</span>
-  - [ ] <span title='not tested'> query_ruleset.delete</span>
-  - [ ] <span title='not tested'> query_ruleset.get</span>
-  - [ ] <span title='not tested'> query_ruleset.list</span>
-  - [ ] <span title='not tested'> query_ruleset.put</span>
+  - [x] <span title='tested'> [query_rules.delete_rule](./tests/query_rules/10_query_rules.yml#L46)</span>
+  - [x] <span title='tested'> [query_rules.delete_ruleset](./tests/query_rules/10_query_rules.yml#L22)</span>
+  - [x] <span title='tested'> [query_rules.get_rule](./tests/query_rules/10_query_rules.yml#L40)</span>
+  - [x] <span title='tested'> [query_rules.get_ruleset](./tests/query_rules/20_rulesets.yml#L29)</span>
+  - [x] <span title='tested'> [query_rules.list_rulesets](./tests/query_rules/20_rulesets.yml#L33)</span>
+  - [x] <span title='tested'> [query_rules.put_rule](./tests/query_rules/10_query_rules.yml#L27)</span>
+  - [x] <span title='tested'> [query_rules.put_ruleset](./tests/query_rules/10_query_rules.yml#L8)</span>
   - [x] <span title='tested'> [rank_eval](./tests/rank_eval.yml#L20)</span>
   - [x] <span title='tested'> [reindex](./tests/reindex/10_basic.yml#L23)</span>
   - [ ] <span title='not tested'> reindex_rethrottle</span>
@@ -1088,10 +1097,10 @@ Endpoints that are currently being tested are marked as done and link to the tes
   - [x] <span title='tested'> [search_application.get](./tests/search_application/10_basic.yml#L48)</span>
   - [x] <span title='tested'> [search_application.get_behavioral_analytics](./tests/search_application/20_behavioral_analytics.yml#L13)</span>
   - [x] <span title='tested'> [search_application.list](./tests/search_application/10_basic.yml#L58)</span>
-  - [ ] <span title='not tested'> search_application.post_behavioral_analytics_event</span>
+  - [x] <span title='tested'> [search_application.post_behavioral_analytics_event](./tests/search_application/30_behavioral_analytics_event.yml#L18)</span>
   - [x] <span title='tested'> [search_application.put](./tests/search_application/10_basic.yml#L24)</span>
   - [x] <span title='tested'> [search_application.put_behavioral_analytics](./tests/search_application/20_behavioral_analytics.yml#L8)</span>
-  - [ ] <span title='not tested'> search_application.render_query</span>
+  - [x] <span title='tested'> [search_application.render_query](./tests/search_application/40_render_query.yml#L77)</span>
   - [x] <span title='tested'> [search_application.search](./tests/search_application/10_basic.yml#L52)</span>
   - [x] <span title='tested'> [search_mvt](./tests/search_mvt/10_basic.yml#L33)</span>
   - [ ] <span title='not tested'> search_shards</span>
@@ -1102,6 +1111,8 @@ Endpoints that are currently being tested are marked as done and link to the tes
   - [ ] <span title='not tested'> searchable_snapshots.stats</span>
   - [ ] <span title='not tested'> security.activate_user_profile</span>
   - [x] <span title='tested'> [security.authenticate](./tests/security/20_authenticate.yml#L8)</span>
+  - [x] <span title='tested'> [security.bulk_delete_role](./tests/security/40_roles.yml#L91)</span>
+  - [x] <span title='tested'> [security.bulk_put_role](./tests/security/40_roles.yml#L64)</span>
   - [ ] <span title='not tested'> security.bulk_update_api_keys</span>
   - [ ] <span title='not tested'> security.change_password</span>
   - [ ] <span title='not tested'> security.clear_api_key_cache</span>
@@ -1113,10 +1124,10 @@ Endpoints that are currently being tested are marked as done and link to the tes
   - [ ] <span title='not tested'> security.create_cross_cluster_api_key</span>
   - [ ] <span title='not tested'> security.create_service_token</span>
   - [ ] <span title='not tested'> security.delete_privileges</span>
-  - [ ] <span title='not tested'> security.delete_role</span>
+  - [x] <span title='tested'> [security.delete_role](./tests/security/40_roles.yml#L23)</span>
   - [ ] <span title='not tested'> security.delete_role_mapping</span>
   - [ ] <span title='not tested'> security.delete_service_token</span>
-  - [ ] <span title='not tested'> security.delete_user</span>
+  - [x] <span title='tested'> [security.delete_user](./tests/security/40_roles.yml#L19)</span>
   - [ ] <span title='not tested'> security.disable_user</span>
   - [ ] <span title='not tested'> security.disable_user_profile</span>
   - [ ] <span title='not tested'> security.enable_user</span>
@@ -1126,7 +1137,7 @@ Endpoints that are currently being tested are marked as done and link to the tes
   - [x] <span title='tested'> [security.get_api_key](./tests/security/10_api_key_basic.yml#L19)</span>
   - [ ] <span title='not tested'> security.get_builtin_privileges</span>
   - [ ] <span title='not tested'> security.get_privileges</span>
-  - [ ] <span title='not tested'> security.get_role</span>
+  - [x] <span title='tested'> [security.get_role](./tests/security/40_roles.yml#L47)</span>
   - [ ] <span title='not tested'> security.get_role_mapping</span>
   - [ ] <span title='not tested'> security.get_service_accounts</span>
   - [ ] <span title='not tested'> security.get_service_credentials</span>
@@ -1144,10 +1155,11 @@ Endpoints that are currently being tested are marked as done and link to the tes
   - [ ] <span title='not tested'> security.oidc_logout</span>
   - [ ] <span title='not tested'> security.oidc_prepare_authentication</span>
   - [ ] <span title='not tested'> security.put_privileges</span>
-  - [ ] <span title='not tested'> security.put_role</span>
+  - [x] <span title='tested'> [security.put_role](./tests/security/40_roles.yml#L29)</span>
   - [ ] <span title='not tested'> security.put_role_mapping</span>
-  - [ ] <span title='not tested'> security.put_user</span>
+  - [x] <span title='tested'> [security.put_user](./tests/security/40_roles.yml#L8)</span>
   - [x] <span title='tested'> [security.query_api_keys](./tests/security/10_api_key_basic.yml#L24)</span>
+  - [x] <span title='tested'> [security.query_role](./tests/security/40_roles.yml#L55)</span>
   - [ ] <span title='not tested'> security.query_user</span>
   - [ ] <span title='not tested'> security.saml_authenticate</span>
   - [ ] <span title='not tested'> security.saml_complete_logout</span>
@@ -1206,6 +1218,7 @@ Endpoints that are currently being tested are marked as done and link to the tes
   - [ ] <span title='not tested'> text_structure.find_structure</span>
   - [ ] <span title='not tested'> text_structure.test_grok_pattern</span>
   - [x] <span title='tested'> [transform.delete_transform](./tests/cat/transform.yml#L28)</span>
+  - [ ] <span title='not tested'> transform.get_node_stats</span>
   - [x] <span title='tested'> [transform.get_transform](./tests/transform/10_basic.yml#L40)</span>
   - [x] <span title='tested'> [transform.get_transform_stats](./tests/transform/10_basic.yml#L43)</span>
   - [x] <span title='tested'> [transform.preview_transform](./tests/transform/10_basic.yml#L46)</span>
@@ -1233,18 +1246,11 @@ Endpoints that are currently being tested are marked as done and link to the tes
   - [ ] <span title='not tested'> watcher.stop</span>
   - [ ] <span title='not tested'> watcher.update_settings</span>
   - [ ] <span title='not tested'> xpack.info</span>
-  - [ ] <span title='not tested'> xpack.usage</span>
+  - [x] <span title='tested'> [xpack.usage](./tests/entsearch/10_basic.yml#L16)</span>
 
 
 ### APIs in JSON spec and not elasticsearch-specification
 
-- [ ] <span title='not tested'> inference.delete_model</span>
-- [ ] <span title='not tested'> inference.get_model</span>
-- [ ] <span title='not tested'> inference.put_model</span>
-- [ ] <span title='not tested'> query_ruleset.delete</span>
-- [ ] <span title='not tested'> query_ruleset.get</span>
-- [ ] <span title='not tested'> query_ruleset.list</span>
-- [ ] <span title='not tested'> query_ruleset.put</span>
 
 
 ### Internal APIs (Not tracked)

--- a/tests/entsearch/10_basic.yml
+++ b/tests/entsearch/10_basic.yml
@@ -1,0 +1,23 @@
+---
+requires:
+  serverless: false
+  stack: true
+---
+"Enterprise Search loaded":
+  - do:
+      cluster.state: {}
+  - set: { master_node: master }
+
+  - do:
+      nodes.info: {}
+  - contains:  { nodes.$master.modules: { name: x-pack-ent-search } }
+
+  - do:
+      xpack.usage: { }
+  - match:
+      enterprise_search:
+        enabled: true
+        available: true
+        search_applications: { count: 0 }
+        analytics_collections: { count: 0 }
+        query_rulesets: { total_count: 0, total_rule_count: 0, min_rule_count: 0, max_rule_count: 0 }

--- a/tests/entsearch/20_connector.yml
+++ b/tests/entsearch/20_connector.yml
@@ -1,0 +1,57 @@
+---
+requires:
+  serverless: true
+  stack: true
+---
+teardown:
+  - do:
+      indices.delete:
+        index: connectors-test
+        ignore: 404
+---
+"Connector":
+  - do:
+      connector.put:
+        connector_id: test-connector-1
+        body:
+          index_name: connectors-test
+  - match: { result: 'created' }
+
+  - do:
+      connector.check_in:
+        connector_id: test-connector-1
+  - match: { result: updated }
+
+  - do:
+      connector.last_sync:
+        connector_id: test-connector-1
+        body:
+          last_sync_error: "oh no error"
+          last_access_control_sync_scheduled_at: "2023-05-25T12:30:00.000Z"
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector-1
+  - match: { index_name: connectors-test }
+  - match: { last_sync_error: "oh no error" }
+  - match: { last_access_control_sync_scheduled_at: "2023-05-25T12:30:00.000Z" }
+
+  - do:
+      connector.list: {}
+  - gte: { count: 1 }
+
+  - do:
+      connector.post: { }
+  - set:  { id: id }
+  - match: { id: $id }
+
+  - do:
+      connector.get:
+        connector_id: $id
+  - match: { id: $id }
+
+  - do:
+      connector.delete:
+        connector_id: test-connector-1
+  - match: { acknowledged: true }

--- a/tests/entsearch/30_sync_jobs_serverless.yml
+++ b/tests/entsearch/30_sync_jobs_serverless.yml
@@ -1,0 +1,50 @@
+---
+requires:
+  serverless: true
+  stack: false
+---
+setup:
+  - do:
+      connector.put:
+        connector_id: test-connector
+        body:
+          index_name: sync-jobs-test
+          name: my-connector
+          language: de
+          is_native: false
+          service_type: super-connector
+---
+teardown:
+  - do:
+      connector.delete:
+        connector_id: test-connector
+---
+"connector.sync_jobs (serverless)":
+  - do:
+      connector.sync_job_post:
+        body:
+          id: test-connector
+          job_type: full
+          trigger_method: on_demand
+  - set:  { id: id }
+  - match: { id: $id }
+
+  - do:
+      connector.sync_job_get:
+        connector_sync_job_id: $id
+  - match: { connector.id: test-connector }
+  - set: { last_seen: last_seen_before_check_in }
+
+  - do:
+      connector.sync_job_cancel:
+        connector_sync_job_id: $id
+  - match: { result: updated }
+
+  - do:
+      connector.sync_job_list: {}
+  - gte: { count: 1 }
+
+  - do:
+      connector.sync_job_delete:
+        connector_sync_job_id: $id
+  - match: { acknowledged: true }

--- a/tests/entsearch/30_sync_jobs_stack.yml
+++ b/tests/entsearch/30_sync_jobs_stack.yml
@@ -1,0 +1,74 @@
+---
+requires:
+  serverless: false
+  stack: true
+---
+setup:
+  - do:
+      connector.put:
+        connector_id: test-connector
+        body:
+          index_name: sync-jobs-test
+          name: my-connector
+          language: de
+          is_native: false
+          service_type: super-connector
+---
+"connector.sync_jobs (stack)":
+  - do:
+      connector.sync_job_post:
+        body:
+          id: test-connector
+          job_type: full
+          trigger_method: on_demand
+  - set:  { id: id }
+  - match: { id: $id }
+
+  - do:
+      connector.sync_job_get:
+        connector_sync_job_id: $id
+  - match: { connector.id: test-connector }
+  - set: { last_seen: last_seen_before_check_in }
+
+  - do:
+      connector.sync_job_check_in:
+        connector_sync_job_id: $id
+  - match: { result: updated }
+
+  - do:
+      connector.sync_job_cancel:
+        connector_sync_job_id: $id
+  - match: { result: updated }
+
+  - do:
+      connector.sync_job_update_stats:
+        connector_sync_job_id: $id
+        body:
+          deleted_document_count: 10
+          indexed_document_count: 20
+          indexed_document_volume: 1000
+
+  - match: { result: updated }
+
+  - do:
+      connector.sync_job_get:
+        connector_sync_job_id: $id
+  - match: { deleted_document_count: 10 }
+  - match: { indexed_document_count: 20 }
+  - match: { indexed_document_volume: 1000 }
+
+  - do:
+      connector.sync_job_list: {}
+  - gte: { count: 1 }
+
+  - do:
+      connector.sync_job_claim:
+        connector_sync_job_id: $id
+        body:
+          worker_hostname: "host-name"
+  - match: { result: updated }
+
+  - do:
+      connector.sync_job_delete:
+        connector_sync_job_id: $id
+  - match: { acknowledged: true }

--- a/tests/entsearch/40_connector_secret.yml
+++ b/tests/entsearch/40_connector_secret.yml
@@ -1,0 +1,26 @@
+---
+requires:
+  serverless: false
+  stack: true
+---
+'connector secret':
+  - do:
+      connector.secret_post:
+        body:
+          value: my-secret
+  - set: { id: id }
+  - match: { id: $id }
+  - do:
+      connector.secret_get:
+        id: $id
+  - match: { value: my-secret }
+  - do:
+      connector.secret_put:
+        id: $id
+        body:
+          value: my-secret-2
+  - match: { result: 'updated' }
+  - do:
+      connector.secret_get:
+        id: $id
+  - match: { value: my-secret-2 }

--- a/tests/entsearch/50_connector_updates.yml
+++ b/tests/entsearch/50_connector_updates.yml
@@ -1,0 +1,244 @@
+---
+requires:
+  stack: true
+  serverless: true
+---
+setup:
+  - do:
+      connector.put:
+        connector_id: test-connector-updates
+        body:
+          index_name: search-1-test
+          name: my-connector
+          language: pl
+          is_native: false
+          service_type: super-connector
+---
+teardown:
+  - do:
+      connector.delete:
+        connector_id: test-connector-updates
+---
+"Update Connector Name":
+  - do:
+      connector.update_name:
+        connector_id: test-connector-updates
+        body:
+          name: test-name
+  - match: { result: updated }
+
+  - do:
+      connector.update_filtering:
+        connector_id: test-connector-updates
+        body:
+          advanced_snippet:
+            created_at: "2023-05-25T12:30:00.000Z"
+            updated_at: "2023-05-25T12:30:00.000Z"
+            value:
+              - tables:
+                  - some_table
+                query: 'SELECT id, st_geohash(coordinates) FROM my_db.some_table;'
+          rules:
+            - created_at: "2023-06-25T12:30:00.000Z"
+              field: _
+              id: DEFAULT
+              order: 0
+              policy: include
+              rule: regex
+              updated_at: "2023-05-25T12:30:00.000Z"
+              value: ".*"
+  - match: { result: updated }
+
+  - do:
+      connector.update_filtering_validation:
+        connector_id: test-connector-updates
+        body:
+          validation:
+            state: valid
+            errors: []
+  - match: { result: updated }
+
+
+  - do:
+      connector.update_active_filtering:
+        connector_id: test-connector-updates
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector-updates
+  - match: { filtering.0.draft.advanced_snippet.created_at: "2023-05-25T12:30:00.000Z" }
+  - match: { filtering.0.draft.advanced_snippet.value.0.tables.0.: "some_table" }
+  - match: { filtering.0.draft.rules.0.created_at: "2023-06-25T12:30:00.000Z" }
+  - match: { filtering.0.active.advanced_snippet.created_at: "2023-05-25T12:30:00.000Z" }
+  - match: { filtering.0.active.advanced_snippet.value.0.tables.0.: "some_table" }
+  - match: { filtering.0.active.rules.0.created_at: "2023-06-25T12:30:00.000Z" }
+
+  - do:
+      connector.update_error:
+        connector_id: test-connector-updates
+        body:
+          error: "some error"
+  - match: { result: updated }
+
+  - do:
+      connector.update_configuration:
+        connector_id: test-connector-updates
+        body:
+          configuration:
+            some_field:
+              default_value: null
+              depends_on:
+                - field: some_field
+                  value: 31
+              display: numeric
+              label: Very important field
+              options: [ ]
+              order: 4
+              required: true
+              sensitive: false
+              tooltip: Wow, this tooltip is useful.
+              type: str
+              ui_restrictions: [ ]
+              validations:
+                - constraint: 0
+                  type: greater_than
+              value: 123
+            yet_another_field:
+              default_value: null
+              depends_on:
+                - field: some_field
+                  value: 31
+              display: numeric
+              label: Another important field
+              options: [ ]
+              order: 4
+              required: true
+              sensitive: false
+              tooltip: Wow, this tooltip is useful.
+              type: str
+              ui_restrictions: [ ]
+              validations:
+                - constraint: 0
+                  type: greater_than
+              value: "peace & love"
+
+  - do:
+      connector.get:
+        connector_id: test-connector-updates
+  - match: { configuration.some_field.value: 123 }
+  - match: { configuration.some_field.sensitive: false }
+  - match: { configuration.some_field.display: numeric }
+  - match: { status: configured }
+  - match: { configuration.yet_another_field.value: "peace & love" }
+
+  - do:
+      connector.update_index_name:
+        connector_id: test-connector-updates
+        body:
+          index_name: search-2-test
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector-updates
+  - match: { index_name: search-2-test }
+
+  - do:
+      connector.put:
+        connector_id: test-connector-native
+        body:
+          index_name: search-3-test
+          name: my-connector
+          language: pl
+          is_native: false
+          service_type: super-connector
+
+  - do:
+      connector.update_native:
+        connector_id: test-connector-native
+        body:
+          is_native: true
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector-native
+  - match: { is_native: true }
+  - match: { status: configured }
+
+  - do:
+      connector.update_pipeline:
+        connector_id: test-connector-updates
+        body:
+          pipeline:
+            extract_binary_content: true
+            name: test-pipeline
+            reduce_whitespace: true
+            run_ml_inference: false
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector-updates
+  - match: { pipeline.extract_binary_content: true }
+  - match: { pipeline.name: test-pipeline }
+  - match: { pipeline.reduce_whitespace: true }
+  - match: { pipeline.run_ml_inference: false }
+
+  - do:
+      connector.update_scheduling:
+        connector_id: test-connector-updates
+        body:
+          scheduling:
+            access_control:
+              enabled: true
+              interval: 1 0 0 * * ?
+            full:
+              enabled: false
+              interval: 2 0 0 * * ?
+            incremental:
+              enabled: false
+              interval: 3 0 0 * * ?
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector-updates
+  - match: { scheduling.access_control.enabled: true }
+  - match: { scheduling.access_control.interval: "1 0 0 * * ?" }
+  - match: { scheduling.full.enabled: false }
+  - match: { scheduling.full.interval: "2 0 0 * * ?" }
+  - match: { scheduling.incremental.enabled: false }
+  - match: { scheduling.incremental.interval: "3 0 0 * * ?" }
+
+  - do:
+      connector.update_status:
+        connector_id: test-connector-updates
+        body:
+          status: needs_configuration
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector-updates
+  - match: { status: needs_configuration }
+
+  - do:
+      connector.update_service_type:
+        connector_id: test-connector-updates
+        body:
+          service_type: even-better-connector
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector-updates
+  - match: { service_type: even-better-connector }
+
+  - do:
+      connector.update_api_key_id:
+        connector_id: test-connector-updates
+        body:
+          api_key_id: test-api-key-id
+  - match: { result: updated }

--- a/tests/entsearch/60_connector_updates_stack.yml
+++ b/tests/entsearch/60_connector_updates_stack.yml
@@ -1,0 +1,35 @@
+---
+requires:
+  stack: true
+  serverless: false
+---
+setup:
+  - do:
+      connector.put:
+        connector_id: test-connector-updates
+        body:
+          index_name: search-1-test
+          name: my-connector
+          language: pl
+          is_native: false
+          service_type: super-connector
+---
+teardown:
+  - do:
+      connector.delete:
+        connector_id: test-connector-updates
+---
+'connector updates stack':
+  - do:
+      connector.update_features:
+        connector_id: test-connector-updates
+        body:
+          features:
+            document_level_security: { enabled: true }
+  - match: { result: updated }
+
+
+  - do:
+      connector.get:
+        connector_id: test-connector-updates
+  - match: { features.document_level_security.enabled: true }

--- a/tests/search_application/30_behavioral_analytics_event.yml
+++ b/tests/search_application/30_behavioral_analytics_event.yml
@@ -1,0 +1,28 @@
+---
+requires:
+  serverless: false
+  stack: true
+---
+setup:
+  - do:
+      search_application.put_behavioral_analytics:
+        name: my-test-analytics-collection
+---
+teardown:
+  - do:
+      search_application.delete_behavioral_analytics:
+        name: my-test-analytics-collection
+---
+"Post page_view analytics event":
+  - do:
+      search_application.post_behavioral_analytics_event:
+        collection_name: my-test-analytics-collection
+        event_type: "page_view"
+        body:
+          session:
+            id: "123"
+          user:
+            id: "456"
+          page:
+            url: "https://www.elastic.co"
+  - is_true: accepted

--- a/tests/search_application/40_render_query.yml
+++ b/tests/search_application/40_render_query.yml
@@ -1,0 +1,82 @@
+---
+requires:
+  stack: true
+  serverless: false
+---
+setup:
+  - do:
+      indices.create:
+        index: test-search-index1
+        body:
+          settings:
+            index:
+              number_of_shards: 1
+              number_of_replicas: 0
+
+  - do:
+      indices.create:
+        index: test-search-index2
+        body:
+          settings:
+            index:
+              number_of_shards: 1
+              number_of_replicas: 0
+
+  - do:
+      search_application.put:
+        name: test-search-application
+        body:
+          indices: [ "test-search-index1", "test-search-index2" ]
+          analytics_collection_name: "test-analytics"
+          template:
+            script:
+              source:
+                query:
+                  term:
+                    "{{field_name}}": "{{field_value}}"
+              params:
+                field_name: field1
+                field_value: value1
+
+  - do:
+      index:
+        index: test-search-index1
+        id: doc1
+        body:
+          field1: value1
+          field2: value1
+        refresh: true
+
+  - do:
+      index:
+        index: test-search-index2
+        id: doc2
+        body:
+          field1: value1
+          field3: value3
+        refresh: true
+---
+teardown:
+  - do:
+      search_application.delete:
+        name: test-search-application
+        ignore: 404
+
+  - do:
+      indices.delete:
+        index: test-search-index1
+        ignore: 404
+
+  - do:
+      indices.delete:
+        index: test-search-index2
+        ignore: 404
+---
+'search_application.render_query':
+  - do:
+      search_application.render_query:
+        name: test-search-application
+        body:
+          params:
+            field_name: field2
+  - match: { query: { term: { field2: {value: "value1"} } } }

--- a/tests/security/40_roles.yml
+++ b/tests/security/40_roles.yml
@@ -1,0 +1,94 @@
+---
+requires:
+  serverless: false
+  stack: true
+---
+setup:
+  - do:
+      security.put_user:
+        username: "joe"
+        body:  >
+            {
+              "password": "s3krit-password",
+              "roles" : [ "admin_role" ]
+            }
+
+---
+teardown:
+  - do:
+      security.delete_user:
+        username: "joe"
+        ignore: 404
+  - do:
+      security.delete_role:
+        name: "admin_role"
+        ignore: 404
+---
+"Test put role api":
+  - do:
+      security.put_role:
+        name: "admin_role"
+        body:  >
+            {
+              "metadata": {
+                "key1" : "val1",
+                "key2" : "val2"
+              },
+              "indices": [
+                {
+                  "names": "*",
+                  "privileges": ["all"]
+                }
+              ]
+            }
+  - match: { role: { created: true } }
+
+  - do:
+      security.get_role:
+        name: "admin_role"
+  - match: { admin_role.metadata.key1:  "val1" }
+  - match: { admin_role.metadata.key2:  "val2" }
+  - match: { admin_role.indices.0.names.0: "*" }
+  - match: { admin_role.indices.0.privileges.0:  "all" }
+
+  - do:
+      security.query_role:
+        body: >
+          {
+            "query": { "match_all": {} }, "sort": ["name"]
+          }
+  - gte: { total: 1 }
+  - gte: { count: 1 }
+  - match: { roles.0.name: "admin_role" }
+  - do:
+      security.bulk_put_role:
+        body:  >
+          {
+            "roles": {
+              "test_admin_role": {
+                "description": "This is my test role",
+                "metadata": {
+                  "key1": "val1",
+                  "key2": "val2"
+                },
+                "indices": [
+                  {
+                    "names": "*",
+                    "privileges": [ "all" ]
+                  }
+                ]
+              }
+            }
+          }
+  - match: { created: ["test_admin_role"] }
+
+  - do:
+      security.get_role:
+        name: "test_admin_role"
+  - match: { test_admin_role.description:  "This is my test role" }
+
+  - do:
+      security.bulk_delete_role:
+        body:
+          names: ["test_admin_role"]
+  - match: { deleted.0: "test_admin_role" }


### PR DESCRIPTION
There are some new `entsearch` tests in the YAML Elasticsearch tests. They need the creation of two new users and roles. The users are created [here](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/ent-search/qa/rest/build.gradle#L33) as `entsearch-user:entsearch-user-password` with the role `user`: and `entsearch-unprivileged:entsearch-unprivileged-password` with the role `unprivileged`. The role definitions can be found [here](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/ent-search/qa/rest/roles.yml#L17-L43).

The [build](https://buildkite.com/elastic/elasticsearch-ruby/builds/3358#01907b0b-79a8-4693-85a8-8a3aca8e65db) broke for the Ruby stack client and would need to be updated to address these failures. Instead, I'm going to skip those tests and migrate the tests here.

According to the generated report, **we are back to (almost) 100% coverage for Serverless**. 
The three remaining APIs:
*  `ml.flush_job` - We have #31 for this.
*  `security.update_api_key` - This is a tricky one. I tried adding it to our API key tests, but it was erroring. The docs say: `It’s not possible to use an API key as the authentication credential for this API. To update an API key, the owner user’s credentials are required`. Our clients authenticate with API key, so I don't know if this would make sense to have this endpoint in the clients, as far as I understand, we can't use this API with API key? 🤷
* `tasks.get` - is not available on Serverless:   [410] api_not_available_exception - Request for uri [/_tasks/] with method [GET] exists but is not available when running in serverless mode