### PR TITLE
Adds test for connector.sync_job_error

### DIFF
--- a/tests/entsearch/30_sync_jobs_stack.yml
+++ b/tests/entsearch/30_sync_jobs_stack.yml
@@ -72,3 +72,18 @@ setup:
       connector.sync_job_delete:
         connector_sync_job_id: $id
   - match: { acknowledged: true }
+
+  - do:
+      connector.sync_job_post:
+        body:
+          id: test-connector
+          job_type: full
+          trigger_method: on_demand
+  - set: { id: id }
+
+  - do:
+      catch: bad_request
+      connector.sync_job_error:
+        connector_sync_job_id: $id
+        body:
+          error: error


### PR DESCRIPTION
Adds a `catch` argument in the test. From Elasticsearch tests:
If the arguments to do include catch, then we are expecting an error, which should be caught and tested.

This would be part of #84, but since I added a `catch` argument, I opened a different Pull Request to make sure all clients using these tests support it. ~I'll rebase once #84 is merged.~ (Rebased)