### PR TITLE
Updates in STACK_VERSION for report

### DIFF
--- a/.github/make.sh
+++ b/.github/make.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# ------------------------------------------------------- #
+#
+# Build entry script for elasticsearch tests
+#
+# Must be called: ./.github/make.sh <target> <params>
+#
+# Version: 1.0.0
+#
+# Targets:
+# ---------------------------
+# bumpmatrix <VERSION> : bump stack version in test matrix to version
+# ------------------------------------------------------- #
+script_path=$(dirname "$(realpath -s "$0")")
+repo=$(realpath "$script_path/../")
+
+# shellcheck disable=SC1090
+CMD=$1
+VERSION=$2
+STACK_VERSION=$VERSION
+set -euo pipefail
+
+case $CMD in
+    bumpmatrix)
+      if [ -v $VERSION ]; then
+        echo -e "\033[31;1mTARGET: bumpmatrix -> missing version parameter\033[0m"
+        exit 1
+      fi
+      echo -e "\033[36;1mTARGET: bump stack in test matrix to version $VERSION\033[0m"
+      sed -i "s/[0-9]\+\.[0-9]\+\.[0-9]\+-SNAPSHOT/$VERSION-SNAPSHOT/" $repo/.github/workflows/report.yml
+
+      ;;
+    *)
+        echo -e "\nUsage:"
+        echo -e "\t Bump stack version:"
+        echo -e "\t $0 bumpmatrix [version_qualifier]\n"
+        exit 1
+esac
+

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           ruby-version: 3.3
         env:
-          STACK_VERSION: 8.15.0-SNAPSHOT
+          STACK_VERSION: 8.16.0-SNAPSHOT
       - name: Build
         run: |
           cd report && bundle install

--- a/report/Rakefile
+++ b/report/Rakefile
@@ -11,7 +11,14 @@ end
 
 desc 'Download Elasticsearch Stack artifacts'
 task :download_json do
-  Elastic::download_json_spec(ENV['STACK_VERSION'] || '8.14.0-SNAPSHOT')
+  version = ENV['STACK_VERSION'] || read_version_from_github
+  Elastic::download_json_spec(version)
+end
+
+def read_version_from_github
+  yml = File.read(File.expand_path('../.github/workflows/report.yml', __dir__))
+  regexp = /[0-9.]+(-SNAPSHOT)?/
+  yml.split("\n").select { |l| l.match?('STACK_VERSION') }.first.strip.match(regexp)[0]
 end
 
 desc 'Download Elasticsearch Serverless artifacts'


### PR DESCRIPTION
@ezimuel @JoshMock Since we're now branching this to follow minor releases for when we fully replace the ES tests with this project, I added this functionality so we keep `main` up to date with the latest snapshot.

I'm hooking this up to the `bumpmatrix` automation so that the `main` branch gets automatic version updates for `STACK_VERSION` in the report. I used [@ezimuel's regexp](https://github.com/elastic/elasticsearch-php/blob/main/.github/make.sh#L160-L174) for the bump. With this change, the report gets the version from `.github/workflows/report.yml` or `ENV['STACK_VERSION']`, but since report.yml will be updated automatically when there's a new snapshot available in main, we probably won't need that very often. 