### PR TITLE
Updates async_search test

### DIFF
--- a/tests/async_search/10_basic.yml
+++ b/tests/async_search/10_basic.yml
@@ -35,8 +35,8 @@ teardown:
       async_search.submit:
         index: async_search_test_10
         q: 'julio'
-        wait_for_completion_timeout: 0
-  - match: { is_partial: true }
+        keep_on_completion: true
+  - match: { response.hits.hits.0._source.name: 'Bestiario' }
   - set:   { id: id }
 
   - do:


### PR DESCRIPTION
This test is a bit flaky in my Stack client build. With this change, I think it won't fail since in such a simple scenario it should hopefully complete and return the query right away, while still keeping the id to test the other async endpoints.