### PR TITLE
License header

### DIFF
--- a/.github/check_license_headers.rb
+++ b/.github/check_license_headers.rb
@@ -1,0 +1,33 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+LICENSE = File.read('./.github/license-header.txt')
+files = `git ls-files | grep -E '\.rb|Rakefile|\.rake|\.erb|Gemfile|gemspec'`.split("\n")
+errors = []
+
+files.each do |file|
+  unless File.read(file).include?(LICENSE)
+    errors << file
+    puts "#{file} doesn't contain the correct license header"
+  end
+end
+
+if errors.empty?
+  puts 'All checked files have the correct license header'
+else
+  exit 1
+end

--- a/.github/license-header.txt
+++ b/.github/license-header.txt
@@ -1,0 +1,16 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,13 @@
+name: License headers
+on: [pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.3'
+    - name: Check license headers
+      run: |
+        ruby ./.github/check_license_headers.rb

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # Elasticsearch Clients Tests
 
-This repository holds common tests for Elasticsearch Clients.
-
-## Yaml tests
-
-The tests are specified using the Elasticsearch YAML format reported [here](https://github.com/elastic/elasticsearch/blob/main/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/README.asciidoc).
+This repository holds common tests for Elasticsearch Clients. The tests are specified using the Elasticsearch YAML format reported [here](https://github.com/elastic/elasticsearch/blob/main/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/README.asciidoc).
 
 All the tests are located in the [tests](tests) folder. Each API endpoint has a folder containing the tests to be executed. All the files must be executed in order, they are enumerated with a digit prefix.
 
@@ -63,38 +59,9 @@ Once in the interactive shell you'll have access to the data. You can run `downl
  @test_stack={:file=>"./tests/async_search/10_basic.yml", :line=>53}>
 3.3.4 :003 > @reporter.namespaces
  =>
-["async_search",
- "cat",
- "ccr",
- "cluster",
- "connector",
- "dangling_indices",
- "enrich",
- "eql",
- "esql",
- "features",
- "fleet",
- "graph",
- "ilm",
- "indices",
- "inference",
- "ingest",
- "license",
- "logstash",
- "migration",
- "ml",
- "monitoring",
- "nodes",
- "query_rules",
- "search_application",
- "searchable_snapshots",
- "security",
- "simulate",
- "slm",
- "synonyms",
- "tasks",
- "text_structure",
- "transform",
- "watcher",
- "xpack"]
+["async_search", "cat", "ccr", "cluster", "connector", "dangling_indices", "enrich", "eql", "esql",
+"features", "fleet", "graph", "ilm", "indices", "inference", "ingest", "license", "logstash",
+"migration", "ml", "monitoring", "nodes", "query_rules", "search_application",
+"searchable_snapshots", "security", "simulate", "slm", "synonyms", "tasks", "text_structure",
+"transform", "watcher", "xpack"]
 ```

--- a/report/Gemfile
+++ b/report/Gemfile
@@ -1,3 +1,20 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 source 'https://rubygems.org'
 
 gem 'rake'

--- a/report/Rakefile
+++ b/report/Rakefile
@@ -1,3 +1,20 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 require 'erb'
 require './download_artifacts'
 require './reporter'

--- a/report/console.rb
+++ b/report/console.rb
@@ -1,3 +1,20 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 require 'json'
 require 'rake'
 require_relative 'reporter'

--- a/report/download_artifacts.rb
+++ b/report/download_artifacts.rb
@@ -1,3 +1,20 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 require 'pathname'
 require 'open-uri'
 require 'json'

--- a/report/lib/api_endpoint.rb
+++ b/report/lib/api_endpoint.rb
@@ -1,3 +1,20 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 module Elastic
   class ApiEndpoint
     TESTS_PATH = File.expand_path('../tests/**/*.yml')

--- a/report/reporter.rb
+++ b/report/reporter.rb
@@ -1,3 +1,20 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 require_relative 'lib/api_endpoint'
 
 module Elastic

--- a/report/template.erb
+++ b/report/template.erb
@@ -1,3 +1,21 @@
+<%
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+-%>
 # Elasticsearch Tests report
 
 Endpoints that are currently being tested are marked as done and link to the test where they're being used.


### PR DESCRIPTION
Adds License Header to Ruby source code files and a GitHub Action to make sure we don't forget to add them to new files. If we add any other programming language scripts, we would have to modify the script to include their file extensions.