### PR TITLE
[CI] Runs report for 8.x

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -5,7 +5,7 @@ on:
     - cron: "0 6 * * 1"
   push:
     branches:
-      - main
+      - 8.x
 jobs:
   generate_report:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since Elasticsearch `main` is now `9.0.0`, I created the `8.x` branch. This Pull Request updates the GitHub Action for the report to run on `8.x` too. Once `8.16` comes out, we'll branch it from `8.x` and `8.x` will be bumped to `8.17`. Just like the old days.

For clients running these tests, we need to target the `8.x` branch here for `main` on our clients, unless the `8.x` branch is already created and you've bumped `main` to `9.0.0`. 