### PR TITLE
fix: /_data_stream/_stats unavailable in serverless

### DIFF
--- a/tests/indices/data_streams.yml
+++ b/tests/indices/data_streams.yml
@@ -33,10 +33,6 @@ teardown:
   - match: { data_streams.0.name: logs-test }
 
   - do:
-      indices.data_streams_stats: {}
-  - is_true: data_streams
-
-  - do:
       indices.delete_data_stream:
         name: logs-test
   - is_true: acknowledged


### PR DESCRIPTION
In [my most recent test run](https://buildkite.com/elastic/elasticsearch-serverless-js-integration-tests/builds/1262), serverless responded with:

```
api_not_available_exception Root causes: api_not_available_exception: Request for uri [/_data_stream/_stats] with method [GET] exists but is not available when running in serverless mode
```
