### PR TITLE
Updates inference/10_basic.yml test

### DIFF
--- a/tests/inference/10_basic.yml
+++ b/tests/inference/10_basic.yml
@@ -19,13 +19,13 @@ requires:
             }
           }
   - match: { task_type: sparse_embedding }
-  - match: { service: elser }
+  - match: { inference_id: elser_model_test }
 
   - do:
       inference.get:
         inference_id: elser_model_test
   - match: { endpoints.0.task_type: sparse_embedding }
-  - match: { endpoints.0.service: elser }
+  - match: { endpoints.0.inference_id: elser_model_test }
 
   - do:
       inference.inference:


### PR DESCRIPTION
In Elasticsearch 9.x, the response is now being set as `elasticsearch` instead of `elser` for `service`. I updated the test to depend on other values based on the data we send in the request.