### PR TITLE
Updates trained model tests

### DIFF
--- a/tests/machine_learning/20_trained_model_serverless.yml
+++ b/tests/machine_learning/20_trained_model_serverless.yml
@@ -1,7 +1,7 @@
 ---
 requires:
   serverless: true
-  stack: true
+  stack: false
 ---
 teardown:
   - do:
@@ -63,6 +63,17 @@ teardown:
           }
   - match: { assignment.task_parameters.model_id: test_model }
   - match: { assignment.task_parameters.number_of_allocations: 1 }
+  - do:
+      ml.infer_trained_model:
+        model_id: "test_model"
+        body: >
+          {
+            "docs": [
+              { "input": "words" }
+            ]
+          }
+  - is_true: inference_results
+
   - do:
       ml.stop_trained_model_deployment:
         model_id: test_model


### PR DESCRIPTION
Infer trained model works on Serverless as long as we use the latest URL: `/_ml/trained_models/{model_id}/deployment/_infer` is deprecated. Use `/_ml/trained_models/{model_id}/_infer instead`

This adds a test for the API in Serverless.