### PR TITLE
Adds tasks test for serverless

### DIFF
--- a/tests/tasks_serverless.yml
+++ b/tests/tasks_serverless.yml
@@ -1,7 +1,7 @@
 ---
 requires:
-  serverless: false
-  stack: true
+  serverless: true
+  stack: false
 ---
 setup:
   - do:
@@ -14,11 +14,7 @@ teardown:
         index: task_test
         ignore: 404
 ---
-"tasks":
-  - do:
-      tasks.get: {}
-  - is_true: nodes
-
+"Task":
   - do:
       update_by_query:
         index: task_test
@@ -33,12 +29,3 @@ teardown:
   - do:
       tasks.get: { task_id: 'node_id:123456' }
       catch: resource_not_found_exception
-
-  - do:
-      tasks.list: {}
-  - is_true: nodes
-
-  - do:
-      tasks.cancel:
-        actions: "unknown_action"
-  - length: { nodes: 0 }


### PR DESCRIPTION
AFAIK we can't see the list of tasks in Serverless, so I wrote a test that catches the 404 when trying to get an invalid task.

```
"type":"resource_not_found_exception",
"reason":"task [node_id:123456] belongs to the node [node_id] which isn't part of the cluster and there is no record of the task"
```