### PR TITLE
Updates scroll test

### DIFF
--- a/tests/scroll/10_basic.yml
+++ b/tests/scroll/10_basic.yml
@@ -21,10 +21,12 @@ teardown:
   - set: { _scroll_id: id }
   - do:
       scroll:
-        scroll_id: $id
         scroll: '1m'
+        body:
+          scroll_id: $id
   - match: { _scroll_id: $id }
   - do:
       clear_scroll:
-        scroll_id: $id
+        body:
+          scroll_id: $id
   - match { succeeded: true }


### PR DESCRIPTION
Sending scroll_id as a parameter is deprecated, it should be sent in the body