### PR TITLE
Wait for trained model to be fully allocated

### DIFF
--- a/tests/machine_learning/20_trained_model_serverless.yml
+++ b/tests/machine_learning/20_trained_model_serverless.yml
@@ -52,7 +52,8 @@ teardown:
       ml.start_trained_model_deployment:
         model_id: test_model
         priority: "low"
-        wait_for: started
+        wait_for: fully_allocated
+        timeout: "60s"
   - match: { assignment.task_parameters.model_id: test_model }
   - do:
       ml.update_trained_model_deployment:


### PR DESCRIPTION
Unfortunately the Python client [does not currently sleep between retries](https://github.com/elastic/elasticsearch-py/issues/2485), which means the fix from https://github.com/elastic/elasticsearch-clients-tests/issues/83 isn't currently enough to pass the tests added in #140. This change, however, fixes the problem in the meantime. Thanks @ezimuel for the pointer.