### PR TITLE
Updates entsearch connector tests

### DIFF
--- a/tests/entsearch/50_connector_updates.yml
+++ b/tests/entsearch/50_connector_updates.yml
@@ -129,7 +129,6 @@ teardown:
   - match: { configuration.some_field.value: 123 }
   - match: { configuration.some_field.sensitive: false }
   - match: { configuration.some_field.display: numeric }
-  - match: { status: configured }
   - match: { configuration.yet_another_field.value: "peace & love" }
 
   - do:
@@ -148,7 +147,7 @@ teardown:
       connector.put:
         connector_id: test-connector-native
         body:
-          index_name: search-3-test
+          index_name: content-search-3-test
           name: my-connector
           language: pl
           is_native: false
@@ -165,7 +164,6 @@ teardown:
       connector.get:
         connector_id: test-connector-native
   - match: { is_native: true }
-  - match: { status: configured }
 
   - do:
       connector.update_pipeline:


### PR DESCRIPTION
Removing the status as it depends on timing (the status can either be `created` or `configured`) and renamed the index to address `The index name [search-3-test] attached to the connector [test-connector-native] must start with the required prefix: [content-] to be Elastic-managed.`.