### PR TITLE
Adds branches to report automation

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -6,16 +6,13 @@ on:
   push:
     branches:
       - main
-      - '8.x'
-      - '8.17'
-      - '8.16'
 jobs:
   generate_report:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         branch:
-          - main
+          - 'main'
           - '8.x'
           - '8.17'
           - '8.16'
@@ -38,11 +35,19 @@ jobs:
         run: cd report && bundle exec rake download_all
       - name: Generate report
         run: cd report && bundle exec rake report
-      - uses: gr2m/create-or-update-pull-request-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        id: cpr
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Updates API report ${{env.REPORT_DATE}} ${{ matrix.branch }}
-          title: Updates API report
+          branch: update_report_${{ matrix.branch }}
+          title: Updates API report ${{ matrix.branch }}
+          body: 'As titled'
+          base: ${{ matrix.branch }}
+          committer: 'Elastic Machine <elasticmachine@users.noreply.github.com>'
           author: 'Elastic Machine <elasticmachine@users.noreply.github.com>'
-          branch: ${{ matrix.branch }}
+      - name: Pull Request Summary
+        if: ${{ steps.cpr.outputs.pull-request-url }}
+        run: |
+          echo "${{ matrix.branch }} - ${{ steps.cpr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -6,13 +6,25 @@ on:
   push:
     branches:
       - main
+      - '8.x'
+      - '8.17'
+      - '8.16'
 jobs:
   generate_report:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branch:
+          - main
+          - '8.x'
+          - '8.17'
+          - '8.16'
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+          ref: ${{ matrix.branch }}
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.3
@@ -30,6 +42,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          commit-message: Updates API report ${{env.REPORT_DATE}}
+          commit-message: Updates API report ${{env.REPORT_DATE}} ${{ matrix.branch }}
           title: Updates API report
           author: 'Elastic Machine <elasticmachine@users.noreply.github.com>'
+          branch: ${{ matrix.branch }}


### PR DESCRIPTION
I updated the GitHub Action for the report to include `8.x`, and the current releases.

Tested [here](https://github.com/elastic/elasticsearch-clients-tests/actions/runs/12545899389).