### PR TITLE
Updates to report logic to download the right branch for report

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -13,13 +13,6 @@ jobs:
     env:
       STACK_VERSION: 9.0.0-SNAPSHOT
       BRANCH: 'main' # Branch for downloading the specs
-    strategy:
-      matrix:
-        branch:
-          - 'main'
-          - '8.x'
-          - '8.17'
-          - '8.16'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   generate_report:
     runs-on: ubuntu-latest
+    env:
+      STACK_VERSION: 9.0.0-SNAPSHOT
+      BRANCH: 'main' # Branch for downloading the specs
     strategy:
       matrix:
         branch:
@@ -21,13 +24,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-          ref: ${{ matrix.branch }}
+          ref: ${{ env.BRANCH }}
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.3
-        env:
-          STACK_VERSION: 9.0.0-SNAPSHOT
       - name: Build
         run: |
           cd report && bundle install
@@ -41,14 +42,14 @@ jobs:
         id: cpr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: Updates API report ${{env.REPORT_DATE}} ${{ matrix.branch }}
-          branch: update_report_${{ matrix.branch }}
-          title: Updates API report ${{ matrix.branch }}
+          commit-message: Updates API report ${{env.REPORT_DATE}} ${{ env.BRANCH }}
+          branch: update_report_${{ env.BRANCH }}
+          title: Updates API report ${{ env.BRANCH }}
           body: 'As titled'
-          base: ${{ matrix.branch }}
+          base: ${{ env.BRANCH }}
           committer: 'Elastic Machine <elasticmachine@users.noreply.github.com>'
           author: 'Elastic Machine <elasticmachine@users.noreply.github.com>'
       - name: Pull Request Summary
         if: ${{ steps.cpr.outputs.pull-request-url }}
         run: |
-          echo "${{ matrix.branch }} - ${{ steps.cpr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY
+          echo "${{ env.BRANCH }} - ${{ steps.cpr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY

--- a/report/Rakefile
+++ b/report/Rakefile
@@ -28,14 +28,7 @@ end
 
 desc 'Download Elasticsearch Stack artifacts'
 task :download_json do
-  version = ENV['STACK_VERSION'] || read_version_from_github
-  Elastic::download_json_spec(version)
-end
-
-def read_version_from_github
-  yml = File.read(File.expand_path('../.github/workflows/report.yml', __dir__))
-  regexp = /[0-9.]+(-SNAPSHOT)?/
-  yml.split("\n").select { |l| l.match?('STACK_VERSION') }.first.strip.match(regexp)[0]
+  Elastic::download_json_spec
 end
 
 desc 'Download Elasticsearch Serverless artifacts'


### PR DESCRIPTION
- Adds branch to downloading elasticsearch-specification.
- Adds getting the version for artifacts from the snapshots url.
- Fixes `8.x` branches reporting on `main`.

I noticed `8.x` branches are using `main` for the report automation. This change should hopefully fix this once it's backported to `8.16`, `8.17` and `8.x` in this repo.