### PR TITLE
[8.17][Backport] Updates to report logic to download the right branch for report

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -1,14 +1,15 @@
 name: report
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 6 * * 1"
   push:
     branches:
-      - main
+      - 8.17
 jobs:
   generate_report:
     runs-on: ubuntu-latest
+    env:
+      STACK_VERSION: 8.17.2-SNAPSHOT
+      BRANCH: 8.17 # Branch for downloading the specs
     steps:
       - uses: actions/checkout@v4
         with:
@@ -16,8 +17,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.3
-        env:
-          STACK_VERSION: 8.17.1-SNAPSHOT
       - name: Build
         run: |
           cd report && bundle install
@@ -26,10 +25,19 @@ jobs:
         run: cd report && bundle exec rake download_all
       - name: Generate report
         run: cd report && bundle exec rake report
-      - uses: gr2m/create-or-update-pull-request-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        id: cpr
         with:
-          commit-message: Updates API report ${{env.REPORT_DATE}}
-          title: Updates API report
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Updates API report ${{env.REPORT_DATE}} ${{ env.BRANCH }}
+          branch: update_report_${{ env.BRANCH }}
+          title: Updates API report ${{ env.BRANCH }}
+          body: 'As titled'
+          base: ${{ env.BRANCH }}
+          committer: 'Elastic Machine <elasticmachine@users.noreply.github.com>'
           author: 'Elastic Machine <elasticmachine@users.noreply.github.com>'
+      - name: Pull Request Summary
+        if: ${{ steps.cpr.outputs.pull-request-url }}
+        run: |
+          echo "${{ env.BRANCH }} - ${{ steps.cpr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY

--- a/report/Rakefile
+++ b/report/Rakefile
@@ -28,14 +28,7 @@ end
 
 desc 'Download Elasticsearch Stack artifacts'
 task :download_json do
-  version = ENV['STACK_VERSION'] || read_version_from_github
-  Elastic::download_json_spec(version)
-end
-
-def read_version_from_github
-  yml = File.read(File.expand_path('../.github/workflows/report.yml', __dir__))
-  regexp = /[0-9.]+(-SNAPSHOT)?/
-  yml.split("\n").select { |l| l.match?('STACK_VERSION') }.first.strip.match(regexp)[0]
+  Elastic::download_json_spec
 end
 
 desc 'Download Elasticsearch Serverless artifacts'


### PR DESCRIPTION
- Adds branch to download for elasticsearch-specification.
- Adds getting the version for artifacts from the snapshots url.
- Fixes `8.x` branches reporting on `main`.

Backports https://github.com/elastic/elasticsearch-clients-tests/pull/197