### PR TITLE
[8.16] Report: Fixes branch value in github action

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   generate_report:
     runs-on: ubuntu-latest
+    env:
+      STACK_VERSION: 8.16.4-SNAPSHOT
+      BRANCH: '8.16' # Branch for downloading the specs
     steps:
       - uses: actions/checkout@v4
         with:
@@ -18,9 +21,6 @@ jobs:
         run: |
           cd report && bundle install
           echo "REPORT_DATE=`date "+%Y-%m-%d|%H:%M:%S"`" >> $GITHUB_ENV
-        env:
-          STACK_VERSION: 8.17.1-SNAPSHOT
-          BRANCH: ${{ matrix.branch }} # Branch for downloading the specs
       - name: Download Artifacts
         run: cd report && bundle exec rake download_all
       - name: Generate report
@@ -30,14 +30,14 @@ jobs:
         id: cpr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: Updates API report ${{env.REPORT_DATE}} ${{ matrix.branch }}
-          branch: update_report_${{ matrix.branch }}
-          title: Updates API report ${{ matrix.branch }}
+          commit-message: Updates API report ${{env.REPORT_DATE}} ${{ env.BRANCH }}
+          branch: update_report_${{ env.BRANCH }}
+          title: Updates API report ${{ env.BRANCH }}
           body: 'As titled'
-          base: ${{ matrix.branch }}
+          base: ${{ env.BRANCH }}
           committer: 'Elastic Machine <elasticmachine@users.noreply.github.com>'
           author: 'Elastic Machine <elasticmachine@users.noreply.github.com>'
       - name: Pull Request Summary
         if: ${{ steps.cpr.outputs.pull-request-url }}
         run: |
-          echo "${{ matrix.branch }} - ${{ steps.cpr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY
+          echo "${{ env.BRANCH }} - ${{ steps.cpr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This fixes the GitHub Action to use the right branch for reports. I've tested this [here](https://github.com/elastic/elasticsearch-clients-tests/pull/210), after merging I'll port these changes to the corresponding branches for `8.17` and `8.x`.