### PR TITLE
Update data_streams.yml

### DIFF
--- a/tests/indices/data_streams.yml
+++ b/tests/indices/data_streams.yml
@@ -40,6 +40,3 @@ teardown:
       indices.delete_data_stream:
         name: logs-test
   - is_true: acknowledged
-  - do:
-      cluster.health:
-        wait_for_status: green


### PR DESCRIPTION
The test timeouts with `"status":"yellow","timed_out":true,"`, we might not need this anymore since the names are updated to be unique and other tests wouldn't step on this while it's still being deleted.