### PR TITLE
Stop testing graph/explore on serverless

### DIFF
--- a/tests/graph/explore.yml
+++ b/tests/graph/explore.yml
@@ -1,5 +1,6 @@
 ---
 requires:
+  serverless: false
   stack: true
 ---
 setup:

--- a/tests/graph/explore.yml
+++ b/tests/graph/explore.yml
@@ -1,6 +1,5 @@
 ---
 requires:
-  serverless: true
   stack: true
 ---
 setup:


### PR DESCRIPTION
It was removed in https://github.com/elastic/elasticsearch/pull/120789