### PR TITLE
Updates inference test

### DIFF
--- a/tests/machine_learning/30_trained_model_stack.yml
+++ b/tests/machine_learning/30_trained_model_stack.yml
@@ -72,7 +72,7 @@ teardown:
               { "input": "words" }
             ]
           }
-  - is_true: predicted_value
+  - is_true: inference_results
   - do:
       ml.stop_trained_model_deployment:
         model_id: model-2


### PR DESCRIPTION
When updating the endpoint code on the stack client with the elasticsearch-specification, it changes the path of `infer_trained_model`:
```diff
-          path   = ("_ml/trained_models/#{Utils.__listify(_model_id)}/deployment/_infer" if _model_id)
+          path   = "_ml/trained_models/#{Utils.__listify(_model_id)}/_infer"
````
When using the first path, the response is:
`{"predicted_value" => [[1.0, 1.0]]}`

But with the updated path, it's returning:
`{"inference_results" => [{"predicted_value" => [[1.0, 1.0]]}]}`