### PR TITLE
Updates README.md - Adds links to reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Elasticsearch Clients Tests
 
+📊 [Test coverage **main**](https://github.com/elastic/elasticsearch-clients-tests/blob/main/apis_report.md#elasticsearch-tests-report) | 📊 [Test coverage **9.x**](https://github.com/elastic/elasticsearch-clients-tests/blob/9.x/apis_report.md#elasticsearch-tests-report) | 📊 [Test coverage **8.x**](https://github.com/elastic/elasticsearch-clients-tests/blob/8.x/apis_report.md#elasticsearch-tests-report)
+
 This repository holds common tests for Elasticsearch Clients. The tests are specified using the Elasticsearch YAML format reported [here](https://github.com/elastic/elasticsearch/blob/main/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/README.asciidoc).
 
 All the tests are located in the [tests](tests) folder. Each API endpoint has a folder containing the tests to be executed. All the files must be executed in order, they are enumerated with a digit prefix.


### PR DESCRIPTION
Also need to set up the repo to run the report automation on the current branches (`9.x`, `9.0`, `8.x`, `8.17`, `8.18`) on a schedule like we do `main`. It looks like [this (9.x)](https://github.com/elastic/elasticsearch-clients-tests/blob/9.x/.github/workflows/report.yml#L4-L5) is not working, so might have to set it up on `main`.