### PR TITLE
[8.x] Removes inference.inference test, no longer available

### DIFF
--- a/tests/inference/10_basic.yml
+++ b/tests/inference/10_basic.yml
@@ -28,13 +28,6 @@ requires:
   - match: { endpoints.0.inference_id: elser_model_test }
 
   - do:
-      inference.inference:
-        inference_id: elser_model_test
-        body:
-          input: 'The sky above the port was the color of television tuned to a dead channel.'
-  - is_true: sparse_embedding.0.embedding
-
-  - do:
       inference.delete:
         inference_id: elser_model_test
   - match: { acknowledged: true }


### PR DESCRIPTION
I'm removing this test since the endpoint has been deleted/renamed. I'm back/forward porting it to several branches as I work through the code generation on the Ruby client.