### PR TITLE
Update tasks.yml - tasks.get should use id, otherwise use tasks.list

### DIFF
--- a/tests/tasks.yml
+++ b/tests/tasks.yml
@@ -16,10 +16,6 @@ teardown:
 ---
 "tasks":
   - do:
-      tasks.get: {}
-  - is_true: nodes
-
-  - do:
       update_by_query:
         index: task_test
         wait_for_completion: false


### PR DESCRIPTION
Though this can work since the URL is `_tasks/$ID` for `get` and `_tasks` for `list`, following the specification makes id required for get.