### PR TITLE
Adds esql get_query and list_queries tests

### DIFF
--- a/tests/esql/30_queries.yml
+++ b/tests/esql/30_queries.yml
@@ -1,0 +1,13 @@
+requires:
+  serverless: true
+  stack: true
+---
+"ES|QL queries":
+  - do:
+      esql.list_queries: { }
+  - match: { queries: { } }
+
+  - do:
+      catch: /illegal_argument_exception/
+      esql.get_query:
+        id: "foobar"


### PR DESCRIPTION
The test on Elasticsearch doesn't test for a valid id either when using `get_query`. It has the following comment:
```
# Since this feature requires queries in the background, the yaml tests only testedge cases with
# no running queries. The rest are covered by integration tests (See EsqlListQueriesActionIT).
```

[EsqlListQueriesActionIT.java](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlListQueriesActionIT.java) extends `AbstractPausableIntegTestCase`, so I'm assuming they can pause the query during execution of the test.

I tried doing this:
```yaml
  - do:
      esql.async_query:
        body:
          query: "FROM esql-queries-test | EVAL duration_ms = ROUND(event.duration / 1000000.0, 1)"
          keep_on_completion: true
  - set: { id: id }

  - do:
      esql.get_query:
        id: $id
  - match: { id: $id }
```
But that appears to be the wrong id:
```
[400] {"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"malformed task id THE_ID"}],
```