### PR TITLE
Updates format for cat requests

### DIFF
--- a/tests/cat/component_templates.yml
+++ b/tests/cat/component_templates.yml
@@ -6,6 +6,7 @@ requires:
 "cat.component_templates":
 
   - do:
-      cat.component_templates: {}
+      cat.component_templates:
+        format: text
   - match:
       $body: '/metrics/'

--- a/tests/cat/count.yml
+++ b/tests/cat/count.yml
@@ -17,6 +17,19 @@ teardown:
 "cat.count":
 
   - do:
-      cat.count: {}
+      cat.count:
+        format: text
   - match:
       $body: "/\n/"
+
+  - do:
+      cat.count:
+        format: yaml
+  - match:
+      $body: "- epoch"
+
+  - do:
+      cat.count:
+        format: json
+  - match:
+      0.count: /[0-9]+/

--- a/tests/machine_learning/set_upgrade_mode.yml
+++ b/tests/machine_learning/set_upgrade_mode.yml
@@ -85,13 +85,15 @@ teardown:
         datafeed_id: set-upgrade-mode-job-datafeed
 
   - do:
-      cat.tasks: {}
+      cat.tasks:
+        format: text
   - match:
       $body: |
         /.+job.+/
 
   - do:
-      cat.tasks: {}
+      cat.tasks:
+        format: text
   - match:
       $body: |
         /.+datafeed.+/

--- a/tests/migration/20_reindex.yml
+++ b/tests/migration/20_reindex.yml
@@ -7,6 +7,9 @@ teardown:
   - do:
       indices.delete_data_stream:
         name: test-reindex-datastream
+  - do:
+      indices.delete_index_template:
+        name: test-reindex-template
 ---
 "Test migrate_reindex, get_migrate_reindex_status, cancel_migrate_reindex":
   - do:


### PR DESCRIPTION
I added the format for some of the cat requests since they're using `match` based on a regular expression, so `text` is expected. Found this issue while updating headers on my client.

I also added tests for `json` and `yaml` in `count`, so we test that we're processing them right too.