### PR TITLE
Removes format:yaml from cat.count test

### DIFF
--- a/tests/cat/count.yml
+++ b/tests/cat/count.yml
@@ -24,12 +24,6 @@ teardown:
 
   - do:
       cat.count:
-        format: yaml
-  - match:
-      $body: "- epoch"
-
-  - do:
-      cat.count:
         format: json
   - match:
       0.count: /[0-9]+/


### PR DESCRIPTION
Not all clients support YAML responses.