### PR TITLE
Remove Enterprise Search Service Account

### DIFF
--- a/tests/security/90_service_accounts.yml
+++ b/tests/security/90_service_accounts.yml
@@ -16,7 +16,6 @@ teardown:
       security.get_service_accounts:
         namespace: elastic
   - is_true: "elastic/auto-ops"
-  - is_true: "elastic/enterprise-search-server"
   - is_true: "elastic/fleet-server"
   - is_true: "elastic/fleet-server-remote"
   - is_true: "elastic/kibana"


### PR DESCRIPTION
It was removed from Elasticsearch: https://github.com/elastic/elasticsearch/pull/124655 and currently breaks Ruby and Python integration tests.