### PR TITLE
Adds wait_for_completion: false to upgrade_mode test

### DIFF
--- a/tests/machine_learning/set_upgrade_mode.yml
+++ b/tests/machine_learning/set_upgrade_mode.yml
@@ -78,6 +78,7 @@ teardown:
       ml.delete_job:
         job_id: set-upgrade-mode-job
         force: true
+        wait_for_completion: false
 ---
 "Setting upgrade_mode to enabled":
   - do:


### PR DESCRIPTION
The Ruby build has been failing for a while because of this test. If I retry to run failed jobs on Buildkite, eventually the test passes though. The error:

```
Net::ReadTimeout with #<TCPSocket:(closed)>
~/.rvm/gems/ruby-3.4.2/gems/elasticsearch-api-9.0.3/lib/elasticsearch/api/actions/machine_learning/delete_job.rb
```
I tested adding more timeout and retries, but it seems to be flaky (could be a temporary thing on the server side?). If I don't wait for completion, the job is marked for deletion and it doesn't timeout.