### PR TITLE
Updates migration reindex test

### DIFF
--- a/tests/migration/20_reindex.yml
+++ b/tests/migration/20_reindex.yml
@@ -45,8 +45,8 @@ teardown:
   - do:
       indices.get_migrate_reindex_status:
         index: "test-reindex-datastream"
-  - match: { complete: true }
-
+  - is_true: start_time_millis
+  - gte: { total_indices_in_data_stream: 1 }
 
   - do:
       indices.cancel_migrate_reindex:


### PR DESCRIPTION
Another flaky. Instead of depending on the response to be `complete: true`, which is time-sensitive, checks that there is a response and no errors.