### PR TITLE
connectors: use hard deletion

### DIFF
--- a/tests/entsearch/20_connector.yml
+++ b/tests/entsearch/20_connector.yml
@@ -39,4 +39,5 @@ teardown:
   - do:
       connector.delete:
         connector_id: test-connector-1
+        hard: true
   - match: { acknowledged: true }


### PR DESCRIPTION
Without hard deletion, creating a previously deleted connector returns "updated", not "created".

(For context, I wanted to be run this test suite twice in my tests with two different HTTP clients, but failed, and this is the only change worth preserving.)