### PR TITLE
[8.19] Revert "connectors: use hard deletion (#345) (#346)"

### DIFF
--- a/tests/entsearch/20_connector.yml
+++ b/tests/entsearch/20_connector.yml
@@ -39,5 +39,4 @@ teardown:
   - do:
       connector.delete:
         connector_id: test-connector-1
-        hard: true
   - match: { acknowledged: true }


### PR DESCRIPTION
This reverts commit ebafb69f1cf4521fa3fae1ed68348ebfedf60c24.

In 8.19, this test fails with:
```
request [/_connector/test-connector-1] contains unrecognized parameter: [hard]
```