### PR TITLE
Updates tests

### DIFF
--- a/tests/cluster/component_templates.yml
+++ b/tests/cluster/component_templates.yml
@@ -18,7 +18,6 @@ requires:
   - do:
       cluster.exists_component_template:
         name: 'test_component_template'
-  - is_true: ''
 
   - do:
       cluster.get_component_template:

--- a/tests/cluster/delete_voting_config_exclusions.yml
+++ b/tests/cluster/delete_voting_config_exclusions.yml
@@ -1,9 +1,0 @@
----
-requires:
-  serverless: false
-  stack: true
----
-'cluster.delete_voting_config_exclusions':
-  - do:
-      cluster.delete_voting_config_exclusions: {}
-  - is_true: $body

--- a/tests/cluster/voting_config_exclusions.yml
+++ b/tests/cluster/voting_config_exclusions.yml
@@ -3,8 +3,16 @@ requires:
   serverless: false
   stack: true
 ---
-'cluster.post_voting_config_exclusions':
+teardown:
+  - do:
+      cluster.delete_voting_config_exclusions: {}
+---
+'cluster voting_config_exclusions':
   - do:
       cluster.post_voting_config_exclusions:
-        node_ids: "*"
-  - is_true: $body
+        node_ids: nodeId1,nodeId2
+  - do:
+      cluster.state: {}
+  - length: { metadata.cluster_coordination.voting_config_exclusions: 2 }
+  - contains : { metadata.cluster_coordination.voting_config_exclusions: {node_id: "nodeId1", node_name: "_absent_"} }
+  - contains : { metadata.cluster_coordination.voting_config_exclusions: {node_id: "nodeId2", node_name: "_absent_"} }

--- a/tests/entsearch/50_connector_updates.yml
+++ b/tests/entsearch/50_connector_updates.yml
@@ -68,10 +68,10 @@ teardown:
       connector.get:
         connector_id: test-connector-updates
   - match: { filtering.0.draft.advanced_snippet.created_at: "2023-05-25T12:30:00.000Z" }
-  - match: { filtering.0.draft.advanced_snippet.value.0.tables.0.: "some_table" }
+  - match: { filtering.0.draft.advanced_snippet.value.0.tables.0: "some_table" }
   - match: { filtering.0.draft.rules.0.created_at: "2023-06-25T12:30:00.000Z" }
   - match: { filtering.0.active.advanced_snippet.created_at: "2023-05-25T12:30:00.000Z" }
-  - match: { filtering.0.active.advanced_snippet.value.0.tables.0.: "some_table" }
+  - match: { filtering.0.active.advanced_snippet.value.0.tables.0: "some_table" }
   - match: { filtering.0.active.rules.0.created_at: "2023-06-25T12:30:00.000Z" }
 
   - do:

--- a/tests/exists_source/10_basic.yml
+++ b/tests/exists_source/10_basic.yml
@@ -19,4 +19,3 @@ teardown:
       exists_source:
         index: 'exists_source_index'
         id: $id
-  - is_true: ''

--- a/tests/indices/exists.yml
+++ b/tests/indices/exists.yml
@@ -17,11 +17,9 @@ teardown:
   - do:
       indices.exists:
         index: 'test_index_exists'
-
   - is_true: ''
 
   - do:
       indices.exists:
         index: 'index_that_shouldnt_exist'
-
   - is_false: ''

--- a/tests/indices/index_template.yml
+++ b/tests/indices/index_template.yml
@@ -30,4 +30,3 @@ teardown:
   - do:
       indices.exists_index_template:
         name: test
-  - is_true: ''

--- a/tests/logstash/10_basic.yml
+++ b/tests/logstash/10_basic.yml
@@ -20,7 +20,6 @@ requires:
             queue.type: 'memory'
             queue.max_bytes: '1gb'
             queue.checkpoint.writes: 1024
-  - is_true: ''
 
   - do:
       logstash.get_pipeline: { id: 'logstash_test_pipeline' }
@@ -28,4 +27,3 @@ requires:
 
   - do:
       logstash.delete_pipeline: { id: 'logstash_test_pipeline' }
-  - is_true: ''


### PR DESCRIPTION
I'm updating tests while working on the PHP YAML test runner. Let me know if you see anything that could be an issue for other test runners. 

The way we've been using `is_true: ""` needs to be updated in some tests. It should test that "The specified key exists and has a true value (ie not 0, false, undefined, null or the empty string)". Sometimes it's been used for "the request was successful, even if the response body is empty". I checked the Elasticsearch tests and for these cases they just make a request. If there's an error from Elasticsearch, our tests runners should fail, otherwise everything goes on smoothly. I'm doing that for our tests now, let me know if you think that's ok.

Alternatively, we could add a new function or use [`exists`](https://github.com/elastic/elasticsearch/blob/main/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/README.asciidoc#exists) with an empty value as a way to check that there is a proper response. E.g.:
```
exists: ''
```
Then in the test runners when there's `exists` and an empty value, we could check the response code. But just making the request should be fine? What do you think?