### PR TITLE
Adds a wait for status in jobs crud

### DIFF
--- a/tests/machine_learning/jobs_crud.yml
+++ b/tests/machine_learning/jobs_crud.yml
@@ -72,6 +72,10 @@ teardown:
   - is_true: closed
 
   - do:
+      cluster.health:
+        wait_for_status: yellow
+
+  - do:
       ml.update_job:
         job_id: "job-crud-test-apis"
         body:  >


### PR DESCRIPTION
This makes the update in the test to be executed a bit later, and hopefully avoids a conflict error in the PHP YAML test runners.