### PR TITLE
fix: prevent language-specific differences in number parsing

### DIFF
--- a/tests/script/10_basic.yml
+++ b/tests/script/10_basic.yml
@@ -36,8 +36,8 @@ teardown:
       scripts_painless_execute:
         body:
           script:
-            source: "params.count / params.total"
+            source: "(double)params.count / params.total"
             params:
-              count: 100.0
-              total: 1000.0
+              count: 100
+              total: 1000
   - match: { result: '0.1' }


### PR DESCRIPTION
Resolves a test failure that JS client was skipping for a long time, because the return value was failing equality check due to differing numeric types.