### PR TITLE
fix: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -6,6 +6,10 @@ on:
       - closed
       - labeled
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   backport:
     name: Backport

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -9,6 +9,10 @@ on:
       - 8.19
       - 9.3
       - 9.4
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   generate_report:
     runs-on: ubuntu-latest


### PR DESCRIPTION
InfoSec is changing GITHUB_TOKEN default permissions from read/write to read-only on July 15th. Adding explicit permissions blocks to all workflows that require write access.