### PR TITLE
fix: make async_sql test deterministic

### DIFF
--- a/tests/sql/10_basic.yml
+++ b/tests/sql/10_basic.yml
@@ -44,6 +44,7 @@ teardown:
         format: 'json'
         body:
           keep_alive: '1d'
+          keep_on_completion: true
           wait_for_completion_timeout: '0s'
           query: 'SELECT * FROM sql_test ORDER BY name'
           fetch_size: 1


### PR DESCRIPTION
The `async_sql` test is racy: `wait_for_completion_timeout: '0s'` without `keep_on_completion` means the result is only stored if the query is still running when the timeout fires. On a fast enough server the query finishes first, nothing gets stored, and `sql.get_async_status` 404s with `no such index [.async-search]` (currently failing elasticsearch-py CI against main). `keep_on_completion: true` always stores the result, so the status/get/delete steps are deterministic.